### PR TITLE
Custom tool belt

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -176,6 +176,10 @@ const ysize = 64;
         toolCursorElem.style.width = '30px';
         toolCursorElem.style.height = '30px';
         toolCursorElem.style.display = currentTool !== null ? 'block' : 'none';
+        if(currentTool || sim.selected_item())
+            mouseIcon.style.display = "block";
+        else
+            mouseIcon.style.display = "none";
     }
 
     function renderToolTip(elem, idx){
@@ -249,7 +253,6 @@ const ysize = 64;
                 updateToolBar();
                 renderToolTip(this, currentTool);
             }
-            deselectPlayerInventory();
             updateInventory(sim.get_player_inventory());
             updateToolCursor(currentTool);
         }

--- a/js/main.js
+++ b/js/main.js
@@ -196,6 +196,11 @@ const ysize = 64;
         }
     }
 
+    function deselectPlayerInventory(){
+        selectedInventory = null;
+        sim.deselect_player_inventory();
+    }
+
     // Tool bar
     var toolBarElem = document.getElementById('toolBar');
     toolBarElem.style.borderStyle = 'solid';
@@ -241,6 +246,8 @@ const ysize = 64;
                 updateToolBar();
                 renderToolTip(this, currentTool);
             }
+            deselectPlayerInventory();
+            updateInventory(sim.get_player_inventory());
             updateToolCursor(currentTool);
         }
         toolElem.onmouseenter = function(e){
@@ -434,6 +441,12 @@ const ysize = 64;
             /// Either clicking or start dragging will select the item, so that
             /// it can be moved on drop
             function selectThisItem(itemName){
+                if(selectedInventory === owner && selectedInventoryItem === itemName){
+                    deselectPlayerInventory();
+                    selectedInventoryItem = null;
+                    updateInventorySelection(elem);
+                    return;
+                }
                 selectedInventory = owner;
                 selectedInventoryItem = itemName;
                 if(elem === playerInventoryElem){

--- a/js/main.js
+++ b/js/main.js
@@ -533,6 +533,7 @@ const ysize = 64;
                 // The amount could have changed during dragging, so we'll query current value
                 // from the source inventory.
                 if(sim.move_selected_inventory_item(!data.fromPlayer, idx === 0)){
+                    deselectPlayerInventory();
                     updateInventory(sim.get_player_inventory());
                     updateToolBar();
                     updateStructureInventory();
@@ -768,6 +769,7 @@ const ysize = 64;
         var data = JSON.parse(ev.dataTransfer.getData(textType));
         if(!data.fromPlayer){
             if(sim.move_selected_inventory_item(!data.fromPlayer, data.fromInput)){
+                deselectPlayerInventory();
                 updateInventory(sim.get_player_inventory());
                 updateToolBar();
                 updateStructureInventory();
@@ -781,6 +783,7 @@ const ysize = 64;
         // Update only if the selected inventory is the other one from destination.
         if(sim.get_selected_inventory() !== null){
             if(sim.move_selected_inventory_item(isPlayer, isInput)){
+                deselectPlayerInventory();
                 updateInventory(sim.get_player_inventory());
                 updateToolBar();
                 updateStructureInventory();

--- a/js/main.js
+++ b/js/main.js
@@ -99,6 +99,7 @@ const ysize = 64;
     const container = document.getElementById('container2');
     const containerRect = container.getBoundingClientRect();
     const inventoryElem = document.getElementById('inventory2');
+    const mouseIcon = document.getElementById("mouseIcon");
 
     const toolTip = document.createElement('dim');
     toolTip.setAttribute('id', 'tooltip');
@@ -114,7 +115,8 @@ const ysize = 64;
     infoElem.style.border = '1px solid #00f';
     container.appendChild(infoElem);
 
-    var selectedInventory = null;
+    let selectedInventory = null;
+    let selectedInventoryItem = null;
 
     let miniMapDrag = false;
     const tilesize = 32;
@@ -199,6 +201,7 @@ const ysize = 64;
     function deselectPlayerInventory(){
         selectedInventory = null;
         sim.deselect_player_inventory();
+        mouseIcon.style.display = "none";
     }
 
     // Tool bar
@@ -405,7 +408,7 @@ const ysize = 64;
         return img;
     }
 
-    function updateInventoryInt(elem, owner, icons, [inventory, selectedInventoryItem]){
+    function updateInventoryInt(elem, owner, icons, [inventory, item]){
         // Local function to update DOM elements based on selection
         function updateInventorySelection(elem){
             for(var i = 0; i < elem.children.length; i++){
@@ -414,7 +417,9 @@ const ysize = 64;
                     celem.itemName === selectedInventoryItem ? "#00ffff" : "";
             }
         }
-    
+
+        selectedInventoryItem = item;
+
         // Clear the elements first
         while(elem.firstChild)
             elem.removeChild(elem.firstChild);
@@ -451,6 +456,11 @@ const ysize = 64;
                 selectedInventoryItem = itemName;
                 if(elem === playerInventoryElem){
                     sim.select_player_inventory(selectedInventoryItem);
+                    mouseIcon.style.display = "block";
+                    let imageFile = getImageFile(selectedInventoryItem);
+                    if(imageFile instanceof Array)
+                        imageFile = imageFile[0];
+                    mouseIcon.style.backgroundImage = `url(${imageFile})`;
                 }
                 else{
                     sim.select_structure_inventory(selectedInventoryItem);
@@ -853,6 +863,13 @@ const ysize = 64;
             document.body.removeChild(downloadLink);
         }
     };
+
+    const body = document.body;
+    body.addEventListener("mousemove", (evt) => {
+        let mousePos = [evt.clientX, evt.clientY];
+        mouseIcon.style.left = `${mousePos[0]}px`;
+        mouseIcon.style.top = `${mousePos[1]}px`;
+    });
 
     const loadFile = document.getElementById('loadFile');
     loadFile.addEventListener('change', (event) => {

--- a/js/main.js
+++ b/js/main.js
@@ -301,8 +301,6 @@ const ysize = 64;
         alert(`FactorishState.render_init failed: ${e}`);
     }
 
-    updateToolBarImage();
-
     function updateToolBarImage(){
         for(var i = 0; i < toolBarCanvases.length; i++){
             var canvasElem = toolBarCanvases[i];
@@ -848,6 +846,8 @@ const ysize = 64;
     catch(e){
         console.error(e);
     }
+
+    updateToolBarImage();
 
     window.addEventListener( "beforeunload", () => sim.save_game());
 

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -142,7 +142,7 @@ impl Structure for Inserter {
             structures
                 .dyn_iter_mut()
                 .find(|structure| *structure.position() == position)
-        };
+        }
 
         if self.hold_item.is_none() {
             if self.cooldown <= 1. {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,13 +357,18 @@ impl Player {
         self.inventory.add_items(name, count);
     }
 
-    fn select_item(&mut self, name: &ItemType) -> Result<(), JsValue> {
-        if self.inventory.get(name).is_some() {
-            self.selected_item = Some(*name);
-            Ok(())
+    fn select_item(&mut self, item: Option<&ItemType>) -> Result<(), JsValue> {
+        if let Some(item) = item {
+            if self.inventory.get(item).is_some() {
+                self.selected_item = Some(*item);
+                Ok(())
+            } else {
+                self.selected_item = None;
+                Err(JsValue::from_str("item not found"))
+            }
         } else {
             self.selected_item = None;
-            Err(JsValue::from_str("item not found"))
+            Ok(())
         }
     }
 }
@@ -1266,9 +1271,14 @@ impl FactorishState {
     }
 
     pub fn select_player_inventory(&mut self, name: &str) -> Result<(), JsValue> {
-        self.player.select_item(
+        self.player.select_item(Some(
             &str_to_item(name).ok_or_else(|| JsValue::from_str("Item name not identified"))?,
-        )
+        ))
+    }
+
+    /// Deselect is a separate function from select because wasm-bindgen cannot overload Option
+    pub fn deselect_player_inventory(&mut self) -> Result<(), JsValue> {
+        self.player.select_item(None)
     }
 
     pub fn open_structure_inventory(&mut self, c: i32, r: i32) -> Result<(), JsValue> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,7 @@ impl SelectedItem {
 
 #[wasm_bindgen]
 pub struct FactorishState {
+    #[allow(dead_code)]
     delta_time: f64,
     sim_time: f64,
     width: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1394,29 +1394,30 @@ impl FactorishState {
         to_player: bool,
         is_input: bool,
     ) -> Result<bool, JsValue> {
-        if let Some(pos) = self.selected_structure_inventory {
-            if let Some(idx) = self.find_structure_tile_idx(&[pos.x, pos.y]) {
-                if let Some(inventory) = self.structures[idx].inventory_mut(is_input) {
-                    let (src, dst, item_name) = if to_player {
-                        (
-                            inventory,
-                            &mut self.player.inventory,
-                            &self.selected_structure_item,
-                        )
-                    } else {
-                        (
-                            &mut self.player.inventory,
-                            inventory,
-                            &self.player.selected_item,
-                        )
-                    };
-                    // console_log!("moving {:?}", item_name);
-                    if let Some(item_name) = item_name {
-                        if FactorishState::move_inventory_item(src, dst, item_name) {
-                            self.on_player_update
-                                .call1(&window(), &JsValue::from(self.get_player_inventory()?))?;
-                            return Ok(true);
-                        }
+        if let Some(idx) = self
+            .selected_structure_inventory
+            .and_then(|pos| self.find_structure_tile_idx(&[pos.x, pos.y]))
+        {
+            if let Some(inventory) = self.structures.get_mut(idx).expect("structure out of bounds").inventory_mut(is_input) {
+                let (src, dst, item_name) = if to_player {
+                    (
+                        inventory,
+                        &mut self.player.inventory,
+                        &self.selected_structure_item,
+                    )
+                } else {
+                    (
+                        &mut self.player.inventory,
+                        inventory,
+                        &self.player.selected_item,
+                    )
+                };
+                // console_log!("moving {:?}", item_name);
+                if let Some(item_name) = item_name {
+                    if FactorishState::move_inventory_item(src, dst, item_name) {
+                        self.on_player_update
+                            .call1(&window(), &JsValue::from(self.get_player_inventory()?))?;
+                        return Ok(true);
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1533,7 +1533,7 @@ impl FactorishState {
         let mut events = vec![];
 
         if button == 0 {
-            if let Some(selected_tool) = self.get_selected_tool_or_item() {
+            if let Some(selected_tool) = self.get_selected_tool_or_item_opt() {
                 if let Some(count) = self.player.inventory.get(&selected_tool) {
                     if 1 <= *count {
                         let mut new_s = self.new_structure(&selected_tool, &cursor)?;
@@ -1876,6 +1876,23 @@ impl FactorishState {
         }
     }
 
+    /// Returns count of selected item or null
+    pub fn get_selected_item(&self) -> JsValue {
+        if let Some(selected_item) = self.player.selected_item {
+            JsValue::from_f64(*self.player.inventory.get(&selected_item).unwrap_or(&0) as f64)
+        } else {
+            JsValue::null()
+        }
+    }
+
+    pub fn get_selected_tool_or_item(&self) -> JsValue {
+        if let Some(selected_item) = self.get_selected_tool_or_item_opt() {
+            JsValue::from_str(&item_to_str(&selected_item))
+        } else {
+            JsValue::null()
+        }
+    }
+
     /// Renders a tool item on the toolbar icon.
     pub fn render_tool(
         &self,
@@ -1923,7 +1940,7 @@ impl FactorishState {
         }
     }
 
-    fn get_selected_tool_or_item(&self) -> Option<ItemType> {
+    fn get_selected_tool_or_item_opt(&self) -> Option<ItemType> {
         self.selected_tool
             .and_then(|tool| self.tool_belt[tool])
             .or_else(|| {
@@ -2203,7 +2220,7 @@ impl FactorishState {
 
         if let Some(ref cursor) = self.cursor {
             let (x, y) = ((cursor[0] * 32) as f64, (cursor[1] * 32) as f64);
-            if let Some(selected_tool) = self.get_selected_tool_or_item() {
+            if let Some(selected_tool) = self.get_selected_tool_or_item_opt() {
                 context.save();
                 context.set_global_alpha(0.5);
                 let mut tool = self.new_structure(&selected_tool, &Position::from(cursor))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,6 +680,10 @@ impl FactorishState {
             .map_err(|e| js_str!("Serialize error: {}", e))?,
         );
         map.insert(
+            "tool_belt".to_string(),
+            map_err(serde_json::to_value(self.tool_belt), "toolbelt")?,
+        );
+        map.insert(
             "board".to_string(),
             serde_json::to_value(
                 self.board
@@ -836,6 +840,8 @@ impl FactorishState {
                 .take(),
         )
         .map_err(|_| js_str!("drop items deserialization error"))?;
+
+        self.tool_belt = from_value(json_take(&mut json, "tool_belt")?)?;
 
         // Redraw minimap
         self.render_minimap_data()?;

--- a/static/index.html
+++ b/static/index.html
@@ -201,6 +201,7 @@
 		<button id="loadButton">Load saved game</button>
 		<input id="saveText" type="text" value="" style="display: none">
 		<div id="mousecaptor" style="display: none; position: fixed; top: 0px; left: 0px; width: 100%; height: 100%; background-color: rgba(0,0,0,0)"></div>
+		<div id="mouseIcon" class="noselect" style="pointer-events: none; display: none; position: fixed; top: 0px; left: 0px; width: 32px; height: 32px"></div>
 		<hr>
 		<p>Source on <a href="https://github.com/msakuta/FactorishWasm">GitHub</a>.</p>
 	</body>

--- a/static/index.html
+++ b/static/index.html
@@ -201,7 +201,7 @@
 		<button id="loadButton">Load saved game</button>
 		<input id="saveText" type="text" value="" style="display: none">
 		<div id="mousecaptor" style="display: none; position: fixed; top: 0px; left: 0px; width: 100%; height: 100%; background-color: rgba(0,0,0,0)"></div>
-		<div id="mouseIcon" class="noselect" style="pointer-events: none; display: none; position: fixed; top: 0px; left: 0px; width: 32px; height: 32px"></div>
+		<div id="mouseIcon" class="noselect" style="pointer-events: none; z-index: 2000; display: none; position: fixed; top: 0px; left: 0px; width: 32px; height: 32px"></div>
 		<hr>
 		<p>Source on <a href="https://github.com/msakuta/FactorishWasm">GitHub</a>.</p>
 	</body>


### PR DESCRIPTION
The user can customize the tool belt by clicking on the inventory and click on the empty slot, just like Factorio.

![image](https://user-images.githubusercontent.com/2798715/121087902-f67f2080-c81f-11eb-8e58-110e5fbccfc3.png)

This will allow the player to use more than 10 kinds of structure to place with shortcut keys.

The tool belt setting is saved to the game data, so it will restore on reload.