### PR TITLE
Use Generational ID

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1109,6 +1109,8 @@ let ysize = 64;
     showDebugBBox.addEventListener("click", () => sim.set_debug_bbox(showDebugBBox.checked));
     const showDebugFluidBox = document.getElementById("showDebugFluidBox");
     showDebugFluidBox.addEventListener("click", () => sim.set_debug_fluidbox(showDebugFluidBox.checked));
+    const showDebugPowerNetwork = document.getElementById("showDebugPowerNetwork");
+    showDebugPowerNetwork.addEventListener("click", () => sim.set_debug_power_network(showDebugPowerNetwork.checked));
 
     window.setInterval(function(){
         if(!paused)

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -65,60 +65,6 @@ impl Assembler {
             recipe: None,
         }
     }
-
-    /// Find all power sources that are connected to this structure through wires.
-    fn find_power_sources(
-        &self,
-        state: &mut FactorishState,
-        structures: &mut StructureDynIter,
-    ) -> Vec<Position> {
-        let mut checked = HashMap::<PowerWire, ()>::new();
-        let mut expand_list = HashMap::<Position, Vec<PowerWire>>::new();
-        let mut ret = vec![];
-        let mut check_struct = |position: &Position| {
-            if structures
-                .as_dyn_iter()
-                .dyn_iter()
-                .any(|structure| structure.power_source() && *structure.position() == *position)
-            {
-                ret.push(*position);
-            }
-        };
-        for wire in &state.power_wires {
-            if wire.0 == self.position {
-                expand_list.insert(wire.1, vec![*wire]);
-                checked.insert(*wire, ());
-                check_struct(&wire.1);
-            } else if wire.1 == self.position {
-                expand_list.insert(wire.0, vec![*wire]);
-                checked.insert(*wire, ());
-                check_struct(&wire.0);
-            }
-        }
-        // Simple Dijkstra
-        while !expand_list.is_empty() {
-            let mut next_expand = HashMap::<Position, Vec<PowerWire>>::new();
-            for check in &expand_list {
-                for wire in &state.power_wires {
-                    if checked.get(wire).is_some() {
-                        continue;
-                    }
-                    if wire.0 == *check.0 {
-                        next_expand.insert(wire.1, vec![*wire]);
-                        checked.insert(*wire, ());
-                        check_struct(&wire.1);
-                    } else if wire.1 == *check.0 {
-                        next_expand.insert(wire.0, vec![*wire]);
-                        checked.insert(*wire, ());
-                        check_struct(&wire.1);
-                    }
-                }
-            }
-            expand_list = next_expand;
-        }
-        // console_log!("Assember power sources: {:?}", ret);
-        ret
-    }
 }
 
 impl Structure for Assembler {

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,7 +1,6 @@
 use crate::dyn_iter::DynIter;
 
 use super::{
-    dyn_iter::DynIterMut,
     items::get_item_image_url,
     serialize_impl,
     structure::{Structure, StructureDynIter, StructureId},

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,8 +1,5 @@
 use super::{
-    dyn_iter::DynIterMut,
-    items::get_item_image_url,
-    serialize_impl,
-    structure::{Structure, StructureEntry},
+    dyn_iter::DynIterMut, items::get_item_image_url, serialize_impl, structure::Structure,
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     PowerWire, Recipe, TILE_SIZE,
 };
@@ -207,7 +204,7 @@ impl Structure for Assembler {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        _structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,14 +1,11 @@
-use crate::dyn_iter::DynIter;
-
 use super::{
     items::get_item_image_url,
     serialize_impl,
     structure::{Structure, StructureDynIter, StructureId},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
-    PowerWire, Recipe, TILE_SIZE,
+    Recipe, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use web_sys::CanvasRenderingContext2d;
 

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,5 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, items::get_item_image_url, serialize_impl, structure::Structure,
+    dyn_iter::DynIterMut,
+    items::get_item_image_url,
+    serialize_impl,
+    structure::{Structure, StructureEntry},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     PowerWire, Recipe, TILE_SIZE,
 };
@@ -204,30 +207,30 @@ impl Structure for Assembler {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        _structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;
             // First, check if we need to refill the energy buffer in order to continue the current work.
             // Refill the energy from the fuel
-            if self.power < recipe.power_cost {
-                let mut accumulated = 0.;
-                for position in self.find_power_sources(_state, structures) {
-                    if let Some(structure) = structures
-                        .dyn_iter_mut()
-                        .find(|structure| *structure.position() == position)
-                    {
-                        let demand = self.max_power - self.power - accumulated;
-                        if let Some(energy) = structure.power_outlet(demand) {
-                            accumulated += energy;
-                            // console_log!("draining {:?}kJ of energy with {:?} demand, from {:?}, accumulated {:?}", energy, demand, structure.name(), accumulated);
-                        }
-                    }
-                }
-                self.power += accumulated;
-                self.input_inventory.remove_item(&ItemType::CoalOre);
-                ret = FrameProcResult::InventoryChanged(self.position);
-            }
+            // if self.power < recipe.power_cost {
+            //     let mut accumulated = 0.;
+            //     for position in self.find_power_sources(_state, structures) {
+            //         if let Some(structure) = structures
+            //             .dyn_iter_mut()
+            //             .find(|structure| *structure.position() == position)
+            //         {
+            //             let demand = self.max_power - self.power - accumulated;
+            //             if let Some(energy) = structure.power_outlet(demand) {
+            //                 accumulated += energy;
+            //                 // console_log!("draining {:?}kJ of energy with {:?} demand, from {:?}, accumulated {:?}", energy, demand, structure.name(), accumulated);
+            //             }
+            //         }
+            //     }
+            //     self.power += accumulated;
+            //     self.input_inventory.remove_item(&ItemType::CoalOre);
+            //     ret = FrameProcResult::InventoryChanged(self.position);
+            // }
 
             if self.progress.is_none() {
                 // First, check if we have enough ingredients to finish this recipe.

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -167,7 +167,7 @@ impl Structure for Assembler {
                 for network in &state
                     .power_networks
                     .iter()
-                    .find(|network| network.sinks.iter().find(|id| **id == me).is_some())
+                    .find(|network| network.sinks.contains(&me))
                 {
                     for id in network.sources.iter() {
                         if let Some(source) = structures.get_mut(*id) {

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,5 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, items::get_item_image_url, serialize_impl, structure::Structure,
+    dyn_iter::DynIterMut,
+    items::get_item_image_url,
+    serialize_impl,
+    structure::{Structure, StructureDynIter},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     PowerWire, Recipe, TILE_SIZE,
 };
@@ -204,7 +207,7 @@ impl Structure for Assembler {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        _structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -2,7 +2,7 @@ use super::pipe::Pipe;
 use super::{
     dyn_iter::DynIterMut,
     serialize_impl,
-    structure::Structure,
+    structure::{Structure, StructureDynIter},
     water_well::{FluidBox, FluidType},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     Recipe, TempEnt, COAL_POWER,
@@ -153,7 +153,7 @@ impl Structure for Boiler {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -2,7 +2,7 @@ use super::pipe::Pipe;
 use super::{
     dyn_iter::DynIterMut,
     serialize_impl,
-    structure::Structure,
+    structure::{Structure, StructureEntry},
     water_well::{FluidBox, FluidType},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     Recipe, TempEnt, COAL_POWER,
@@ -153,7 +153,7 @@ impl Structure for Boiler {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -43,8 +43,8 @@ impl Boiler {
                 power_cost: 100.,
                 recipe_time: 30.,
             }),
-            input_fluid_box: FluidBox::new(true, false, [false; 4]),
-            output_fluid_box: FluidBox::new(false, true, [false; 4]),
+            input_fluid_box: FluidBox::new(true, false, [None; 4]),
+            output_fluid_box: FluidBox::new(false, true, [None; 4]),
         }
     }
 

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -1,7 +1,7 @@
 use super::pipe::Pipe;
 use super::{
     serialize_impl,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     water_well::{FluidBox, FluidType},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     Recipe, TempEnt, COAL_POWER,
@@ -151,6 +151,7 @@ impl Structure for Boiler {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -2,7 +2,7 @@ use super::pipe::Pipe;
 use super::{
     dyn_iter::DynIterMut,
     serialize_impl,
-    structure::{Structure, StructureEntry},
+    structure::Structure,
     water_well::{FluidBox, FluidType},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     Recipe, TempEnt, COAL_POWER,
@@ -153,7 +153,7 @@ impl Structure for Boiler {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -1,6 +1,5 @@
 use super::pipe::Pipe;
 use super::{
-    dyn_iter::DynIterMut,
     serialize_impl,
     structure::{Structure, StructureDynIter},
     water_well::{FluidBox, FluidType},
@@ -155,10 +154,8 @@ impl Structure for Boiler {
         state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
-        self.input_fluid_box
-            .simulate(&self.position, state, structures);
-        self.output_fluid_box
-            .simulate(&self.position, state, structures);
+        self.input_fluid_box.simulate(structures);
+        self.output_fluid_box.simulate(structures);
         if let Some(recipe) = &self.recipe {
             if self.input_fluid_box.type_ == Some(FluidType::Water) {
                 self.progress = Some(0.);

--- a/src/dyn_iter.rs
+++ b/src/dyn_iter.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 pub(crate) trait DynIter {
-    type Item;
+    type Item: ?Sized;
     fn dyn_iter(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_>;
     fn as_dyn_iter(&self) -> &dyn DynIter<Item = Self::Item>;
 }

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -1,7 +1,5 @@
 use super::{
-    dyn_iter::DynIterMut,
-    structure::{Structure, StructureEntry},
-    FactorishState, FrameProcResult, Position,
+    dyn_iter::DynIterMut, structure::Structure, FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -64,9 +62,9 @@ impl Structure for ElectPole {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
-        for structure in structures.dyn_iter_mut().filter_map(|s| s.dynamic.as_deref_mut()) {
+        for structure in structures.dyn_iter_mut() {
             let target_position = structure.position();
             if target_position.distance(&self.position) < 3 {
                 if let Some(power) = structure.power_outlet(Self::POWER_CAPACITY - self.power) {

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -1,8 +1,4 @@
-use super::{
-    dyn_iter::DynIterMut,
-    structure::{Structure, StructureDynIter, StructureId},
-    FactorishState, FrameProcResult, Position,
-};
+use super::{structure::Structure, FactorishState, Position};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use web_sys::CanvasRenderingContext2d;
@@ -20,8 +16,6 @@ impl ElectPole {
             power: 0.,
         }
     }
-
-    const POWER_CAPACITY: f64 = 10.;
 }
 
 impl Structure for ElectPole {

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -1,6 +1,6 @@
 use super::{
     dyn_iter::DynIterMut,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,7 @@ impl Structure for ElectPole {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -1,5 +1,7 @@
 use super::{
-    dyn_iter::DynIterMut, structure::Structure, FactorishState, FrameProcResult, Position,
+    dyn_iter::DynIterMut,
+    structure::{Structure, StructureEntry},
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -62,9 +64,9 @@ impl Structure for ElectPole {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
-        for structure in structures.dyn_iter_mut() {
+        for structure in structures.dyn_iter_mut().filter_map(|s| s.dynamic.as_deref_mut()) {
             let target_position = structure.position();
             if target_position.distance(&self.position) < 3 {
                 if let Some(power) = structure.power_outlet(Self::POWER_CAPACITY - self.power) {

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -1,5 +1,7 @@
 use super::{
-    dyn_iter::DynIterMut, structure::Structure, FactorishState, FrameProcResult, Position,
+    dyn_iter::DynIterMut,
+    structure::{Structure, StructureDynIter},
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -62,7 +64,7 @@ impl Structure for ElectPole {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         for structure in structures.dyn_iter_mut() {
             let target_position = structure.position();

--- a/src/elect_pole.rs
+++ b/src/elect_pole.rs
@@ -61,23 +61,6 @@ impl Structure for ElectPole {
         Ok(())
     }
 
-    fn frame_proc(
-        &mut self,
-        _me: StructureId,
-        _state: &mut FactorishState,
-        structures: &mut StructureDynIter,
-    ) -> Result<FrameProcResult, ()> {
-        for structure in structures.dyn_iter_mut() {
-            let target_position = structure.position();
-            if target_position.distance(&self.position) < 3 {
-                if let Some(power) = structure.power_outlet(Self::POWER_CAPACITY - self.power) {
-                    self.power += power;
-                }
-            }
-        }
-        Ok(FrameProcResult::None)
-    }
-
     fn power_sink(&self) -> bool {
         true
     }

--- a/src/furnace.rs
+++ b/src/furnace.rs
@@ -1,6 +1,9 @@
 use super::{
-    dyn_iter::DynIterMut, items::item_to_str, structure::Structure, DropItem, FactorishState,
-    FrameProcResult, Inventory, InventoryTrait, ItemType, Position, Recipe, TempEnt, COAL_POWER,
+    dyn_iter::DynIterMut,
+    items::item_to_str,
+    structure::{Structure, StructureEntry},
+    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
+    Recipe, TempEnt, COAL_POWER,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -110,7 +113,7 @@ impl Structure for Furnace {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        _structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;

--- a/src/furnace.rs
+++ b/src/furnace.rs
@@ -1,6 +1,9 @@
 use super::{
-    dyn_iter::DynIterMut, items::item_to_str, structure::Structure, DropItem, FactorishState,
-    FrameProcResult, Inventory, InventoryTrait, ItemType, Position, Recipe, TempEnt, COAL_POWER,
+    dyn_iter::DynIterMut,
+    items::item_to_str,
+    structure::{Structure, StructureDynIter},
+    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
+    Recipe, TempEnt, COAL_POWER,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -110,7 +113,7 @@ impl Structure for Furnace {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        _structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;

--- a/src/furnace.rs
+++ b/src/furnace.rs
@@ -1,5 +1,4 @@
 use super::{
-    dyn_iter::DynIterMut,
     items::item_to_str,
     structure::{Structure, StructureDynIter},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,

--- a/src/furnace.rs
+++ b/src/furnace.rs
@@ -1,9 +1,6 @@
 use super::{
-    dyn_iter::DynIterMut,
-    items::item_to_str,
-    structure::{Structure, StructureEntry},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
-    Recipe, TempEnt, COAL_POWER,
+    dyn_iter::DynIterMut, items::item_to_str, structure::Structure, DropItem, FactorishState,
+    FrameProcResult, Inventory, InventoryTrait, ItemType, Position, Recipe, TempEnt, COAL_POWER,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -113,7 +110,7 @@ impl Structure for Furnace {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        _structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         if let Some(recipe) = &self.recipe {
             let mut ret = FrameProcResult::None;

--- a/src/furnace.rs
+++ b/src/furnace.rs
@@ -1,6 +1,6 @@
 use super::{
     items::item_to_str,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
     Recipe, TempEnt, COAL_POWER,
 };
@@ -111,6 +111,7 @@ impl Structure for Furnace {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         state: &mut FactorishState,
         _structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -2,7 +2,7 @@ use super::{
     draw_direction_arrow,
     dyn_iter::DynIterMut,
     items::{render_drop_item, ItemType},
-    structure::{Structure, StructureEntry},
+    structure::Structure,
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
 };
 use serde::{Deserialize, Serialize};
@@ -131,18 +131,18 @@ impl Structure for Inserter {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure + '_>,
     ) -> Result<FrameProcResult, ()> {
         let input_position = self.position.add(self.rotation.delta_inv());
         let output_position = self.position.add(self.rotation.delta());
 
-        fn find_structure_at(
-            structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        // It is unclear why I need to put explicit lifetimes to avoid compile errors.
+        fn find_structure_at<'a, 'b>(
+            structures: &'a mut dyn DynIterMut<Item = dyn Structure + 'b>,
             position: Position,
-        ) -> Option<&mut Box<dyn Structure>> {
+        ) -> Option<&'a mut (dyn Structure + 'b)> {
             structures
                 .dyn_iter_mut()
-                .filter_map(|s| s.dynamic.as_mut())
                 .find(|structure| *structure.position() == position)
         }
 
@@ -152,7 +152,7 @@ impl Structure for Inserter {
                 let ret = FrameProcResult::None;
 
                 let mut try_hold =
-                    |structures: &mut dyn DynIterMut<Item = StructureEntry>, type_| -> bool {
+                    |structures: &mut dyn DynIterMut<Item = dyn Structure + '_>, type_| -> bool {
                         if let Some(structure) = find_structure_at(structures, output_position) {
                             // console_log!(
                             //     "found structure to output[{}]: {}, {}, {}",

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -2,7 +2,7 @@ use super::{
     draw_direction_arrow,
     dyn_iter::DynIterMut,
     items::{render_drop_item, ItemType},
-    structure::Structure,
+    structure::{Structure, StructureEntry},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
 };
 use serde::{Deserialize, Serialize};
@@ -131,17 +131,18 @@ impl Structure for Inserter {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         let input_position = self.position.add(self.rotation.delta_inv());
         let output_position = self.position.add(self.rotation.delta());
 
         fn find_structure_at(
-            structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+            structures: &mut dyn DynIterMut<Item = StructureEntry>,
             position: Position,
         ) -> Option<&mut Box<dyn Structure>> {
             structures
                 .dyn_iter_mut()
+                .filter_map(|s| s.dynamic.as_mut())
                 .find(|structure| *structure.position() == position)
         }
 
@@ -151,7 +152,7 @@ impl Structure for Inserter {
                 let ret = FrameProcResult::None;
 
                 let mut try_hold =
-                    |structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>, type_| -> bool {
+                    |structures: &mut dyn DynIterMut<Item = StructureEntry>, type_| -> bool {
                         if let Some(structure) = find_structure_at(structures, output_position) {
                             // console_log!(
                             //     "found structure to output[{}]: {}, {}, {}",

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,6 +1,5 @@
 use super::{
     draw_direction_arrow,
-    dyn_iter::DynIterMut,
     items::{render_drop_item, ItemType},
     structure::{Structure, StructureDynIter, StructureId},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
@@ -45,6 +44,35 @@ impl Inserter {
             self.rotation.angle_rad() + (phase * 0.8 + 0.5) * std::f64::consts::PI,
             self.rotation.angle_rad() + ((1. - phase) * 0.8 + 0.2 - 0.5) * std::f64::consts::PI,
         )
+    }
+
+    fn on_construction_common(
+        &mut self,
+        other_id: StructureId,
+        other: &dyn Structure,
+        construct: bool,
+    ) -> Result<(), JsValue> {
+        let input_position = self.position.add(self.rotation.delta_inv());
+        let output_position = self.position.add(self.rotation.delta());
+        if *other.position() == input_position {
+            self.input_structure = if construct { Some(other_id) } else { None };
+            console_log!(
+                "Inserter{:?}: {} input_structure {:?}",
+                self.position,
+                if construct { "set" } else { "unset" },
+                other_id
+            );
+        }
+        if *other.position() == output_position {
+            self.output_structure = if construct { Some(other_id) } else { None };
+            console_log!(
+                "Inserter{:?}: {} output_structure {:?}",
+                self.position,
+                if construct { "set" } else { "unset" },
+                other_id
+            );
+        }
+        Ok(())
     }
 }
 
@@ -142,45 +170,29 @@ impl Structure for Inserter {
         let input_position = self.position.add(self.rotation.delta_inv());
         let output_position = self.position.add(self.rotation.delta());
 
-        // It is unclear why I need to put explicit lifetimes to avoid compile errors.
-        fn find_structure_at<'a, 'b>(
-            structures: &'a mut dyn DynIterMut<Item = dyn Structure + 'b>,
-            position: Position,
-        ) -> Option<&'a mut (dyn Structure + 'b)> {
-            structures
-                .dyn_iter_mut()
-                .find(|structure| *structure.position() == position)
-        }
-
         if self.hold_item.is_none() {
             if self.cooldown <= 1. {
                 self.cooldown = 0.;
                 let ret = FrameProcResult::None;
 
-                let mut try_hold =
-                    |structures: &mut dyn DynIterMut<Item = dyn Structure + '_>, type_| -> bool {
-                        if let Some(structure) = find_structure_at(structures, output_position) {
-                            // console_log!(
-                            //     "found structure to output[{}]: {}, {}, {}",
-                            //     structure_idx,
-                            //     structure.name(),
-                            //     output_position.x,
-                            //     output_position.y
-                            // );
-                            if structure.can_input(&type_) || structure.movable() {
-                                // ret = FrameProcResult::InventoryChanged(output_position);
-                                self.hold_item = Some(type_);
-                                self.cooldown += INSERTER_TIME;
-                                true
-                            } else {
-                                false
-                            }
-                        } else {
+                let mut try_hold = |structures: &mut StructureDynIter, type_| -> bool {
+                    if let Some(structure) =
+                        self.output_structure.map(|id| structures.get(id)).flatten()
+                    {
+                        if structure.can_input(&type_) || structure.movable() {
+                            // ret = FrameProcResult::InventoryChanged(output_position);
                             self.hold_item = Some(type_);
                             self.cooldown += INSERTER_TIME;
                             true
+                        } else {
+                            false
                         }
-                    };
+                    } else {
+                        self.hold_item = Some(type_);
+                        self.cooldown += INSERTER_TIME;
+                        true
+                    }
+                };
 
                 let mut lets_try_hold = None;
                 if let Some(&DropItem { type_, id, .. }) = state.find_item(&input_position) {
@@ -189,7 +201,11 @@ impl Structure for Inserter {
                     } else {
                         // console_log!("fail output_object: {:?}", type_);
                     }
-                } else if let Some(structure) = find_structure_at(structures, input_position) {
+                } else if let Some(structure) = self
+                    .input_structure
+                    .map(|id| structures.get_mut(id))
+                    .flatten()
+                {
                     lets_try_hold = Some(structure.can_output());
                     // console_log!("outputting from a structure at {:?}", structure.position());
                     // if let Ok((item, callback)) = structure.output(state, &output_position) {
@@ -202,7 +218,9 @@ impl Structure for Inserter {
                 if let Some(output_items) = lets_try_hold {
                     if let Some(type_) = (|| {
                         // First, try matching the item that the structure at the output position can accept.
-                        if let Some(structure) = find_structure_at(structures, output_position) {
+                        if let Some(structure) =
+                            self.output_structure.map(|id| structures.get(id)).flatten()
+                        {
                             // console_log!(
                             //     "found structure to output[{}]: {}, {}, {}",
                             //     structure_idx,
@@ -226,7 +244,11 @@ impl Structure for Inserter {
                         }
                         None
                     })() {
-                        if let Some(structure) = find_structure_at(structures, input_position) {
+                        if let Some(structure) = self
+                            .input_structure
+                            .map(|id| structures.get_mut(id))
+                            .flatten()
+                        {
                             structure.output(state, &type_.0)?;
                             return Ok(FrameProcResult::InventoryChanged(input_position));
                         } else {
@@ -254,15 +276,22 @@ impl Structure for Inserter {
         } else if self.cooldown < 1. {
             self.cooldown = 0.;
             if let Some(item_type) = self.hold_item {
+                let Self {
+                    cooldown,
+                    hold_item,
+                    output_structure,
+                    ..
+                } = self;
                 let mut try_move = |state: &mut FactorishState| {
                     if let Ok(()) =
                         state.new_object(output_position.x, output_position.y, item_type)
                     {
-                        self.cooldown += INSERTER_TIME;
-                        self.hold_item = None;
+                        *cooldown += INSERTER_TIME;
+                        *hold_item = None;
                     }
                 };
-                if let Some(structure) = find_structure_at(structures, output_position) {
+                if let Some(structure) = output_structure.map(|id| structures.get_mut(id)).flatten()
+                {
                     if structure
                         .input(&DropItem::new(
                             &mut state.serial_no,
@@ -272,8 +301,8 @@ impl Structure for Inserter {
                         ))
                         .is_ok()
                     {
-                        self.cooldown += INSERTER_TIME;
-                        self.hold_item = None;
+                        *cooldown += INSERTER_TIME;
+                        *hold_item = None;
                         return Ok(FrameProcResult::InventoryChanged(output_position));
                     } else if structure.movable() {
                         try_move(state)
@@ -294,23 +323,17 @@ impl Structure for Inserter {
         other: &dyn Structure,
         construct: bool,
     ) -> Result<(), JsValue> {
-        let input_position = self.position.add(self.rotation.delta_inv());
-        let output_position = self.position.add(self.rotation.delta());
-        if *other.position() == input_position {
-            self.input_structure = if construct { Some(other_id) } else { None };
-            console_log!(
-                "{} input_structure {:?}",
-                if construct { "set" } else { "unset" },
-                other_id
-            );
-        }
-        if *other.position() == output_position {
-            self.output_structure = if construct { Some(other_id) } else { None };
-            console_log!(
-                "{} input_structure {:?}",
-                if construct { "set" } else { "unset" },
-                other_id
-            );
+        self.on_construction_common(other_id, other, construct)
+    }
+
+    fn on_construction_self(
+        &mut self,
+        _self_id: StructureId,
+        others: &StructureDynIter,
+        construct: bool,
+    ) -> Result<(), JsValue> {
+        for (id, s) in others.dyn_iter_id() {
+            self.on_construction_common(id, s, construct)?;
         }
         Ok(())
     }

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -164,6 +164,7 @@ impl Structure for Inserter {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -2,7 +2,7 @@ use super::{
     draw_direction_arrow,
     dyn_iter::DynIterMut,
     items::{render_drop_item, ItemType},
-    structure::Structure,
+    structure::{Structure, StructureDynIter},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
 };
 use serde::{Deserialize, Serialize};
@@ -131,7 +131,7 @@ impl Structure for Inserter {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure + '_>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         let input_position = self.position.add(self.rotation.delta_inv());
         let output_position = self.position.add(self.rotation.delta());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1157,6 +1157,14 @@ impl FactorishState {
         }
     }
 
+    fn get_structure(&self, id: StructureId) -> Option<&dyn Structure> {
+        self.structures.iter()
+            .enumerate()
+            .find(|(i, s)| id.id == *i as u32 && id.gen == s.gen)
+            .map(|(_, s)| s.dynamic.as_deref())
+            .flatten()
+    }
+
     fn update_fluid_connections(&mut self, position: &Position) -> Result<(), JsValue> {
         if let Some(i) = self
             .structures
@@ -2753,10 +2761,7 @@ impl FactorishState {
             for PowerWire(first, second) in wires {
                 context.begin_path();
                 let first = if let Some(d) = self
-                    .structures
-                    .get(first.id as usize)
-                    .map(|s| s.dynamic.as_ref())
-                    .flatten()
+                    .get_structure(*first)
                 {
                     d.position()
                 } else {
@@ -2767,10 +2772,7 @@ impl FactorishState {
                     first.y as f64 * TILE_SIZE + WIRE_ATTACH_Y,
                 );
                 let second = if let Some(d) = self
-                    .structures
-                    .get(second.id as usize)
-                    .map(|s| s.dynamic.as_ref())
-                    .flatten()
+                    .get_structure(*second)
                 {
                     d.position()
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,7 @@ pub struct FactorishState {
     popup_texts: Vec<PopupText>,
     debug_bbox: bool,
     debug_fluidbox: bool,
+    debug_power_network: bool,
 
     // on_show_inventory: js_sys::Function,
     image_dirt: Option<ImageBundle>,
@@ -672,6 +673,7 @@ impl FactorishState {
             popup_texts: vec![],
             debug_bbox: false,
             debug_fluidbox: false,
+            debug_power_network: false,
             image_dirt: None,
             image_back_tiles: None,
             image_weeds: None,
@@ -1808,6 +1810,10 @@ impl FactorishState {
         self.debug_fluidbox = value;
     }
 
+    pub fn set_debug_power_network(&mut self, value: bool) {
+        self.debug_power_network = value;
+    }
+
     /// Move inventory items between structure and player
     /// @param to_player whether the movement happen towards player
     /// @param inventory_type a string indicating type of the inventory in the structure
@@ -2728,6 +2734,50 @@ impl FactorishState {
 
         const WIRE_ATTACH_X: f64 = 28.;
         const WIRE_ATTACH_Y: f64 = 8.;
+
+        if self.debug_power_network {
+            for (i, nw) in self.power_networks.iter().enumerate() {
+                context.set_stroke_style(&js_str!(
+                    ["rgb(255,0,0)", "rgb(0,0,255)", "rgb(0,255,0)"][i % 3]
+                ));
+                context.set_line_width(3.);
+                for (first, second) in &nw.wires {
+                    context.begin_path();
+                    let first = if let Some(d) = self
+                        .structures
+                        .get(first.id as usize)
+                        .map(|s| s.dynamic.as_ref())
+                        .flatten()
+                    {
+                        d.position()
+                    } else {
+                        continue;
+                    };
+                    context.move_to(
+                        first.x as f64 * TILE_SIZE + WIRE_ATTACH_X,
+                        first.y as f64 * TILE_SIZE + WIRE_ATTACH_Y,
+                    );
+                    let second = if let Some(d) = self
+                        .structures
+                        .get(second.id as usize)
+                        .map(|s| s.dynamic.as_ref())
+                        .flatten()
+                    {
+                        d.position()
+                    } else {
+                        continue;
+                    };
+                    context.quadratic_curve_to(
+                        (first.x + second.x) as f64 / 2. * TILE_SIZE + WIRE_ATTACH_X,
+                        (first.y + second.y) as f64 / 1.9 * TILE_SIZE + WIRE_ATTACH_Y,
+                        second.x as f64 * TILE_SIZE + WIRE_ATTACH_X,
+                        second.y as f64 * TILE_SIZE + WIRE_ATTACH_Y,
+                    );
+                    context.stroke();
+                }
+            }
+        }
+
         context.set_stroke_style(&js_str!("rgb(191,127,0)"));
         context.set_line_width(1.);
         for power_wire in &self.power_wires {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1112,9 +1112,9 @@ impl FactorishState {
                                 .zip(b.1.fluid_box_mut())
                         {
                             av.iter_mut()
-                                .for_each(|fb| fb.connect_to[(idx as usize + 2) % 4] = Some(aid));
+                                .for_each(|fb| fb.connect_to[(idx as usize + 2) % 4] = Some(bid));
                             bv.iter_mut()
-                                .for_each(|fb| fb.connect_to[idx as usize] = Some(bid));
+                                .for_each(|fb| fb.connect_to[idx as usize] = Some(aid));
                         }
                     }
                 }
@@ -1222,13 +1222,10 @@ impl FactorishState {
         // away from self so that they do not claim mutable borrow twice, but it works.
         let mut structures = std::mem::take(&mut self.structures);
         for i in 0..structures.len() {
-            let (front, mid) = structures.split_at_mut(i);
-            let (center, last) = mid
-                .split_first_mut()
-                .ok_or_else(|| JsValue::from_str("Structures split fail"))?;
+            let (center, mut dyn_iter) = StructureDynIter::new(&mut structures, i)?;
             if let Some(dynamic) = center.dynamic.as_deref_mut() {
                 frame_proc_result_to_event(
-                    dynamic.frame_proc(self, &mut StructureDynIter(front, last)), // dynamic.frame_proc(self, &mut Chained(MutRef(front), MutRef(last)))
+                    dynamic.frame_proc(self, &mut dyn_iter), // dynamic.frame_proc(self, &mut Chained(MutRef(front), MutRef(last)))
                 );
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2237,9 +2237,11 @@ impl FactorishState {
         // context.set_fill_style(&JsValue::from_str("#00ff7f"));
         let color = [0x00, 0xff, 0x7f];
         for structure in self.structure_iter() {
-            let Position { x, y } = structure.position();
-            let start = ((x + y * self.width as i32) * 4) as usize;
-            data[start..start + 3].copy_from_slice(&color);
+            let Position { x, y } = *structure.position();
+            if x < self.width as i32 && y < self.height as i32 {
+                let start = ((x + y * self.width as i32) * 4) as usize;
+                data[start..start + 3].copy_from_slice(&color);
+            }
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,7 +1256,14 @@ impl FactorishState {
             let (center, mut dyn_iter) = StructureDynIter::new(&mut structures, i)?;
             if let Some(dynamic) = center.dynamic.as_deref_mut() {
                 frame_proc_result_to_event(
-                    dynamic.frame_proc(self, &mut dyn_iter), // dynamic.frame_proc(self, &mut Chained(MutRef(front), MutRef(last)))
+                    dynamic.frame_proc(
+                        StructureId {
+                            id: i as u32,
+                            gen: center.gen,
+                        },
+                        self,
+                        &mut dyn_iter,
+                    ), // dynamic.frame_proc(self, &mut Chained(MutRef(front), MutRef(last)))
                 );
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -976,6 +976,13 @@ impl FactorishState {
             self.update_fluid_connections(&pos)?;
         }
 
+        for i in 0..self.structures.len() {
+            let (s, others) = StructureDynIter::new(&mut self.structures, i)?;
+            let id = StructureId { id: i as u32, gen: s.gen };
+            s.dynamic.as_deref_mut().map(|d| d.on_construction_self(id, &others, true))
+                .unwrap_or(Ok(()))?;
+        }
+
         self.drop_items = serde_json::from_value(
             json.get_mut("items")
                 .ok_or_else(|| js_str!("\"items\" not found"))?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -966,6 +966,16 @@ impl FactorishState {
 
         self.structures = structures;
 
+        // We need to collect the positions into a temporary Vec to allow passing &mut self to update_fluid_connections
+        for pos in self
+            .structures
+            .iter()
+            .filter_map(|s| Some(*s.dynamic.as_deref()?.position()))
+            .collect::<Vec<_>>()
+        {
+            self.update_fluid_connections(&pos)?;
+        }
+
         self.drop_items = serde_json::from_value(
             json.get_mut("items")
                 .ok_or_else(|| js_str!("\"items\" not found"))?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod water_well;
 use assembler::Assembler;
 use boiler::Boiler;
 use chest::Chest;
-use dyn_iter::{Chained, DynIter, DynIterMut, MutRef, Ref};
+use dyn_iter::{Chained, DynIterMut, MutRef, Ref};
 use elect_pole::ElectPole;
 use furnace::Furnace;
 use inserter::Inserter;
@@ -1002,6 +1002,7 @@ impl FactorishState {
         }
     }
 
+    #[allow(dead_code)]
     fn proc_structures_mutual(
         &mut self,
         mut f: impl FnMut(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1563,6 +1563,15 @@ impl FactorishState {
                 self.player.add_item(&item_type, count)
             }
 
+            self.power_networks = build_power_networks(
+                &StructureDynIter::new_all(&mut self.structures)?,
+                &self.power_wires,
+            );
+            console_log!(
+                "harvest structure: power_networks: {:?}",
+                self.power_networks
+            );
+
             self.update_fluid_connections(&position)?;
 
             self.on_player_update
@@ -2060,7 +2069,7 @@ impl FactorishState {
                             true,
                         )?;
 
-                        // Notify structures after slot has been decided
+                        // Notify structures after a slot has been decided
                         for structure in &mut self.structures {
                             if let Some(s) = structure.dynamic.as_deref_mut() {
                                 s.on_construction(
@@ -2098,6 +2107,12 @@ impl FactorishState {
                                 self.structures.len()
                             );
                         }
+
+                        self.power_networks = build_power_networks(
+                            &StructureDynIter::new_all(&mut self.structures)?,
+                            &self.power_wires,
+                        );
+                        console_log!("build structure: power_networks: {:?}", self.power_networks);
 
                         self.update_fluid_connections(&cursor)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -996,13 +996,6 @@ impl FactorishState {
 
         let s_d_iter = StructureDynIter::new_all(&mut self.structures)?;
         self.power_networks = build_power_networks(&s_d_iter, &self.power_wires);
-        console_log!(
-            "deserialize: power_networks: {:?}",
-            self.power_networks
-                .iter()
-                .map(|nw| format!("{} sources {} sinks", nw.sources.len(), nw.sinks.len()))
-                .collect::<Vec<_>>()
-        );
 
         self.drop_items = serde_json::from_value(
             json.get_mut("items")
@@ -1575,13 +1568,6 @@ impl FactorishState {
                 &StructureDynIter::new_all(&mut self.structures)?,
                 &self.power_wires,
             );
-            console_log!(
-                "harvest structure: power_networks: {:?}",
-                self.power_networks
-                    .iter()
-                    .map(|nw| format!("{} sources {} sinks", nw.sources.len(), nw.sinks.len()))
-                    .collect::<Vec<_>>()
-            );
 
             self.update_fluid_connections(&position)?;
 
@@ -2126,17 +2112,6 @@ impl FactorishState {
                         self.power_networks = build_power_networks(
                             &StructureDynIter::new_all(&mut self.structures)?,
                             &self.power_wires,
-                        );
-                        console_log!(
-                            "build structure: power_networks: {:?}",
-                            self.power_networks
-                                .iter()
-                                .map(|nw| format!(
-                                    "{} sources {} sinks",
-                                    nw.sources.len(),
-                                    nw.sinks.len()
-                                ))
-                                .collect::<Vec<_>>()
                         );
 
                         self.update_fluid_connections(&cursor)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -994,7 +994,13 @@ impl FactorishState {
 
         let s_d_iter = StructureDynIter::new_all(&mut self.structures)?;
         self.power_networks = build_power_networks(&s_d_iter, &self.power_wires);
-        console_log!("power_networks: {:?}", self.power_networks);
+        console_log!(
+            "deserialize: power_networks: {:?}",
+            self.power_networks
+                .iter()
+                .map(|nw| format!("{} sources {} sinks", nw.sources.len(), nw.sinks.len()))
+                .collect::<Vec<_>>()
+        );
 
         self.drop_items = serde_json::from_value(
             json.get_mut("items")
@@ -1570,6 +1576,9 @@ impl FactorishState {
             console_log!(
                 "harvest structure: power_networks: {:?}",
                 self.power_networks
+                    .iter()
+                    .map(|nw| format!("{} sources {} sinks", nw.sources.len(), nw.sinks.len()))
+                    .collect::<Vec<_>>()
             );
 
             self.update_fluid_connections(&position)?;
@@ -2112,7 +2121,17 @@ impl FactorishState {
                             &StructureDynIter::new_all(&mut self.structures)?,
                             &self.power_wires,
                         );
-                        console_log!("build structure: power_networks: {:?}", self.power_networks);
+                        console_log!(
+                            "build structure: power_networks: {:?}",
+                            self.power_networks
+                                .iter()
+                                .map(|nw| format!(
+                                    "{} sources {} sinks",
+                                    nw.sources.len(),
+                                    nw.sinks.len()
+                                ))
+                                .collect::<Vec<_>>()
+                        );
 
                         self.update_fluid_connections(&cursor)?;
 

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -1,7 +1,7 @@
 use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
-    structure::Structure,
+    structure::{Structure, StructureEntry},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position,
 };
@@ -66,7 +66,7 @@ impl Structure for OffshorePump {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -1,6 +1,6 @@
 use super::{
     pipe::Pipe,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position,
 };
@@ -64,6 +64,7 @@ impl Structure for OffshorePump {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -1,7 +1,7 @@
 use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
-    structure::Structure,
+    structure::{Structure, StructureDynIter},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position,
 };
@@ -66,7 +66,7 @@ impl Structure for OffshorePump {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -19,7 +19,7 @@ impl OffshorePump {
     pub(crate) fn new(position: &Position) -> Self {
         OffshorePump {
             position: *position,
-            output_fluid_box: FluidBox::new(false, true, [false; 4]).set_type(&FluidType::Water),
+            output_fluid_box: FluidBox::new(false, true, [None; 4]).set_type(&FluidType::Water),
         }
     }
 }

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -1,5 +1,4 @@
 use super::{
-    dyn_iter::DynIterMut,
     pipe::Pipe,
     structure::{Structure, StructureDynIter},
     water_well::{FluidBox, FluidType},
@@ -65,13 +64,12 @@ impl Structure for OffshorePump {
 
     fn frame_proc(
         &mut self,
-        state: &mut FactorishState,
+        _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);
-        self.output_fluid_box
-            .simulate(&self.position, state, structures);
+        self.output_fluid_box.simulate(structures);
         Ok(FrameProcResult::None)
     }
 

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -1,7 +1,7 @@
 use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
-    structure::{Structure, StructureEntry},
+    structure::Structure,
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position,
 };
@@ -66,7 +66,7 @@ impl Structure for OffshorePump {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,10 +1,7 @@
 use super::{
-    draw_direction_arrow,
-    dyn_iter::DynIterMut,
-    items::ItemType,
-    structure::{Structure, StructureEntry},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe,
-    Rotation, TempEnt, COAL_POWER, TILE_SIZE,
+    draw_direction_arrow, dyn_iter::DynIterMut, items::ItemType, structure::Structure, DropItem,
+    FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe, Rotation,
+    TempEnt, COAL_POWER, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -126,7 +123,7 @@ impl Structure for OreMine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         let otile = &state.tile_at(&self.position);
         if otile.is_none() {
@@ -214,11 +211,8 @@ impl Structure for OreMine {
             if 1. <= self.progress + progress {
                 self.progress = 0.;
                 let output_position = self.position.add(self.rotation.delta());
-                let str_iter = structures.dyn_iter_mut();
-                if let Some(structure) = str_iter
-                    .filter_map(|s| s.dynamic.as_mut())
-                    .find(|s| *s.position() == output_position)
-                {
+                let mut str_iter = structures.dyn_iter_mut();
+                if let Some(structure) = str_iter.find(|s| *s.position() == output_position) {
                     let mut it = recipe.output.iter();
                     if let Some(item) = it.next() {
                         // Check whether we can input first

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,7 +1,10 @@
 use super::{
-    draw_direction_arrow, dyn_iter::DynIterMut, items::ItemType, structure::Structure, DropItem,
-    FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe, Rotation,
-    TempEnt, COAL_POWER, TILE_SIZE,
+    draw_direction_arrow,
+    dyn_iter::DynIterMut,
+    items::ItemType,
+    structure::{Structure, StructureEntry},
+    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe,
+    Rotation, TempEnt, COAL_POWER, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -123,7 +126,7 @@ impl Structure for OreMine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         let otile = &state.tile_at(&self.position);
         if otile.is_none() {
@@ -211,8 +214,11 @@ impl Structure for OreMine {
             if 1. <= self.progress + progress {
                 self.progress = 0.;
                 let output_position = self.position.add(self.rotation.delta());
-                let mut str_iter = structures.dyn_iter_mut();
-                if let Some(structure) = str_iter.find(|s| *s.position() == output_position) {
+                let str_iter = structures.dyn_iter_mut();
+                if let Some(structure) = str_iter
+                    .filter_map(|s| s.dynamic.as_mut())
+                    .find(|s| *s.position() == output_position)
+                {
                     let mut it = recipe.output.iter();
                     if let Some(item) = it.next() {
                         // Check whether we can input first

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,7 +1,10 @@
 use super::{
-    draw_direction_arrow, dyn_iter::DynIterMut, items::ItemType, structure::Structure, DropItem,
-    FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe, Rotation,
-    TempEnt, COAL_POWER, TILE_SIZE,
+    draw_direction_arrow,
+    dyn_iter::DynIterMut,
+    items::ItemType,
+    structure::{Structure, StructureDynIter},
+    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe,
+    Rotation, TempEnt, COAL_POWER, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -123,7 +126,7 @@ impl Structure for OreMine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         let otile = &state.tile_at(&self.position);
         if otile.is_none() {

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -2,7 +2,7 @@ use super::{
     draw_direction_arrow,
     dyn_iter::DynIterMut,
     items::ItemType,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe,
     Rotation, TempEnt, COAL_POWER, TILE_SIZE,
 };
@@ -125,6 +125,7 @@ impl Structure for OreMine {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -16,7 +16,7 @@ impl Pipe {
     pub(crate) fn new(position: &Position) -> Self {
         Pipe {
             position: *position,
-            fluid_box: FluidBox::new(true, true, [false; 4]),
+            fluid_box: FluidBox::new(true, true, [None; 4]),
         }
     }
 
@@ -43,7 +43,8 @@ impl Pipe {
                                 .connect_to
                                 .iter()
                                 .enumerate()
-                                .fold(0, |acc, (i, b)| acc | ((*b as u32) << i)),
+                                .filter(|(_, b)| b.is_some())
+                                .fold(0, |acc, (i, b)| acc | (1 << i)),
                         )
                     })
                     .flatten()

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,6 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, structure::Structure, water_well::FluidBox, FactorishState,
-    FrameProcResult, Position,
+    dyn_iter::DynIterMut,
+    structure::{Structure, StructureDynIter},
+    water_well::FluidBox,
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -103,7 +105,7 @@ impl Structure for Pipe {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.fluid_box.simulate(&self.position, state, structures);
         Ok(FrameProcResult::None)

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,8 +1,6 @@
 use super::{
-    dyn_iter::DynIterMut,
-    structure::{Structure, StructureEntry},
-    water_well::FluidBox,
-    FactorishState, FrameProcResult, Position,
+    dyn_iter::DynIterMut, structure::Structure, water_well::FluidBox, FactorishState,
+    FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -104,7 +102,7 @@ impl Structure for Pipe {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         self.fluid_box.simulate(&self.position, state, structures);
         Ok(FrameProcResult::None)

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,5 +1,5 @@
 use super::{
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     water_well::FluidBox,
     FactorishState, FrameProcResult, Position,
 };
@@ -103,6 +103,7 @@ impl Structure for Pipe {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,5 +1,4 @@
 use super::{
-    dyn_iter::DynIterMut,
     structure::{Structure, StructureDynIter},
     water_well::FluidBox,
     FactorishState, FrameProcResult, Position,
@@ -46,7 +45,7 @@ impl Pipe {
                                 .iter()
                                 .enumerate()
                                 .filter(|(_, b)| b.is_some())
-                                .fold(0, |acc, (i, b)| acc | (1 << i)),
+                                .fold(0, |acc, (i, _)| acc | (1 << i)),
                         )
                     })
                     .flatten()
@@ -104,10 +103,10 @@ impl Structure for Pipe {
 
     fn frame_proc(
         &mut self,
-        state: &mut FactorishState,
+        _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
-        self.fluid_box.simulate(&self.position, state, structures);
+        self.fluid_box.simulate(structures);
         Ok(FrameProcResult::None)
     }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,6 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, structure::Structure, water_well::FluidBox, FactorishState,
-    FrameProcResult, Position,
+    dyn_iter::DynIterMut,
+    structure::{Structure, StructureEntry},
+    water_well::FluidBox,
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -102,7 +104,7 @@ impl Structure for Pipe {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         self.fluid_box.simulate(&self.position, state, structures);
         Ok(FrameProcResult::None)

--- a/src/power_network.rs
+++ b/src/power_network.rs
@@ -5,10 +5,10 @@ use super::{
 use std::collections::HashMap;
 
 #[derive(Debug)]
-pub(in crate) struct PowerNetwork {
-    wires: Vec<(StructureId, StructureId)>,
-    sources: Vec<StructureId>,
-    sinks: Vec<StructureId>,
+pub(crate) struct PowerNetwork {
+    pub wires: Vec<(StructureId, StructureId)>,
+    pub sources: Vec<StructureId>,
+    pub sinks: Vec<StructureId>,
 }
 
 pub(crate) fn build_power_networks(

--- a/src/power_network.rs
+++ b/src/power_network.rs
@@ -1,0 +1,106 @@
+use super::{
+    structure::{StructureDynIter, StructureId},
+    Position, PowerWire,
+};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub(in crate) struct PowerNetwork {
+    wires: Vec<(StructureId, StructureId)>,
+    sources: Vec<StructureId>,
+    sinks: Vec<StructureId>,
+}
+
+pub(crate) fn build_power_networks(
+    structures: &StructureDynIter,
+    power_wires: &[PowerWire],
+) -> Vec<PowerNetwork> {
+    let mut checked = HashMap::<PowerWire, ()>::new();
+    let mut ret = vec![];
+
+    for (id, s) in structures.dyn_iter_id() {
+        if !s.power_sink() && !s.power_source() {
+            continue;
+        }
+        let mut expand_list = HashMap::<Position, Vec<PowerWire>>::new();
+        let mut wires = vec![];
+        let mut sources = vec![];
+        let mut sinks = vec![];
+        if s.power_source() {
+            sources.push(id);
+        }
+        if s.power_sink() {
+            sinks.push(id);
+        }
+
+        let mut check_struct = |position: &Position| {
+            if let Some((id, s)) = structures
+                .dyn_iter_id()
+                .find(|(_, structure)| *structure.position() == *position)
+            {
+                if s.power_source() {
+                    sources.push(id);
+                }
+                if s.power_sink() {
+                    sinks.push(id);
+                }
+                Some(id)
+            } else {
+                None
+            }
+        };
+
+        let mut lr = None;
+        for wire in power_wires {
+            let left = if wire.0 == *s.position() {
+                expand_list.insert(wire.1, vec![*wire]);
+                checked.insert(*wire, ());
+                check_struct(&wire.1)
+            } else {
+                None
+            };
+            let right = if wire.1 == *s.position() {
+                expand_list.insert(wire.0, vec![*wire]);
+                checked.insert(*wire, ());
+                check_struct(&wire.0)
+            } else {
+                None
+            };
+            if let Some((left, right)) = left.zip(right) {
+                lr = Some((left, right));
+                break;
+            }
+        }
+
+        if let Some(lr) = lr {
+            wires.push(lr);
+        }
+        // Simple Dijkstra
+        while !expand_list.is_empty() {
+            let mut next_expand = HashMap::<Position, Vec<PowerWire>>::new();
+            for check in &expand_list {
+                for wire in power_wires.iter() {
+                    if checked.get(wire).is_some() {
+                        continue;
+                    }
+                    if wire.0 == *check.0 {
+                        next_expand.insert(wire.1, vec![*wire]);
+                        checked.insert(*wire, ());
+                        check_struct(&wire.1);
+                    } else if wire.1 == *check.0 {
+                        next_expand.insert(wire.0, vec![*wire]);
+                        checked.insert(*wire, ());
+                        check_struct(&wire.1);
+                    }
+                }
+            }
+            expand_list = next_expand;
+        }
+        ret.push(PowerNetwork {
+            wires,
+            sources,
+            sinks,
+        });
+    }
+    ret
+}

--- a/src/power_network.rs
+++ b/src/power_network.rs
@@ -2,11 +2,11 @@ use super::{
     structure::{StructureDynIter, StructureId},
     PowerWire,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub(crate) struct PowerNetwork {
-    pub wires: Vec<(StructureId, StructureId)>,
+    pub wires: Vec<PowerWire>,
     pub sources: HashSet<StructureId>,
     pub sinks: HashSet<StructureId>,
 }
@@ -15,14 +15,7 @@ pub(crate) fn build_power_networks(
     structures: &StructureDynIter,
     power_wires: &[PowerWire],
 ) -> Vec<PowerNetwork> {
-    let structure_positions = structures
-        .dyn_iter_id()
-        .map(|(id, s)| (*s.position(), id))
-        .collect::<HashMap<_, _>>();
-    let mut left_wires = power_wires
-        .iter()
-        .map(|w| (structure_positions[&w.0], structure_positions[&w.1]))
-        .collect::<HashSet<_>>();
+    let mut left_wires = power_wires.iter().collect::<HashSet<_>>();
     let mut ret = vec![];
 
     for (id, s) in structures.dyn_iter_id() {
@@ -57,7 +50,7 @@ pub(crate) fn build_power_networks(
                 while let Some(wire) = left_wires.iter().find(|w| w.0 == id || w.1 == id).copied() {
                     next_expand.insert(if wire.0 == id { wire.1 } else { wire.0 });
                     left_wires.remove(&wire);
-                    wires.push(wire);
+                    wires.push(*wire);
                 }
             }
             expand_list = next_expand;

--- a/src/power_network.rs
+++ b/src/power_network.rs
@@ -52,6 +52,9 @@ pub(crate) fn build_power_networks(
 
         let mut lr = None;
         for wire in power_wires {
+            if checked.contains_key(wire) {
+                continue;
+            }
             let left = if wire.0 == *s.position() {
                 expand_list.insert(wire.1, vec![*wire]);
                 checked.insert(*wire, ());
@@ -96,11 +99,14 @@ pub(crate) fn build_power_networks(
             }
             expand_list = next_expand;
         }
-        ret.push(PowerNetwork {
-            wires,
-            sources,
-            sinks,
-        });
+
+        if !sources.is_empty() && !sinks.is_empty() {
+            ret.push(PowerNetwork {
+                wires,
+                sources,
+                sinks,
+            });
+        }
     }
     ret
 }

--- a/src/power_network.rs
+++ b/src/power_network.rs
@@ -2,13 +2,13 @@ use super::{
     structure::{StructureDynIter, StructureId},
     Position, PowerWire,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
 pub(crate) struct PowerNetwork {
     pub wires: Vec<(StructureId, StructureId)>,
-    pub sources: Vec<StructureId>,
-    pub sinks: Vec<StructureId>,
+    pub sources: HashSet<StructureId>,
+    pub sinks: HashSet<StructureId>,
 }
 
 pub(crate) fn build_power_networks(
@@ -24,13 +24,13 @@ pub(crate) fn build_power_networks(
         }
         let mut expand_list = HashMap::<Position, Vec<PowerWire>>::new();
         let mut wires = vec![];
-        let mut sources = vec![];
-        let mut sinks = vec![];
+        let mut sources = HashSet::new();
+        let mut sinks = HashSet::new();
         if s.power_source() {
-            sources.push(id);
+            sources.insert(id);
         }
         if s.power_sink() {
-            sinks.push(id);
+            sinks.insert(id);
         }
 
         let mut check_struct = |position: &Position| {
@@ -39,10 +39,10 @@ pub(crate) fn build_power_networks(
                 .find(|(_, structure)| *structure.position() == *position)
             {
                 if s.power_source() {
-                    sources.push(id);
+                    sources.insert(id);
                 }
                 if s.power_sink() {
-                    sinks.push(id);
+                    sinks.insert(id);
                 }
                 Some(id)
             } else {

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -2,7 +2,7 @@ use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
     serialize_impl,
-    structure::Structure,
+    structure::{Structure, StructureDynIter},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position, Recipe,
 };
@@ -130,7 +130,7 @@ impl Structure for SteamEngine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -1,7 +1,7 @@
 use super::{
     pipe::Pipe,
     serialize_impl,
-    structure::{Structure, StructureDynIter},
+    structure::{Structure, StructureDynIter, StructureId},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position, Recipe,
 };
@@ -128,6 +128,7 @@ impl Structure for SteamEngine {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -2,7 +2,7 @@ use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
     serialize_impl,
-    structure::{Structure, StructureEntry},
+    structure::Structure,
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position, Recipe,
 };
@@ -130,7 +130,7 @@ impl Structure for SteamEngine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -2,7 +2,7 @@ use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
     serialize_impl,
-    structure::Structure,
+    structure::{Structure, StructureEntry},
     water_well::{FluidBox, FluidType},
     FactorishState, FrameProcResult, Position, Recipe,
 };
@@ -130,7 +130,7 @@ impl Structure for SteamEngine {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         self.input_fluid_box
             .simulate(&self.position, state, structures);

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -1,5 +1,4 @@
 use super::{
-    dyn_iter::DynIterMut,
     pipe::Pipe,
     serialize_impl,
     structure::{Structure, StructureDynIter},
@@ -129,11 +128,10 @@ impl Structure for SteamEngine {
 
     fn frame_proc(
         &mut self,
-        state: &mut FactorishState,
+        _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
-        self.input_fluid_box
-            .simulate(&self.position, state, structures);
+        self.input_fluid_box.simulate(structures);
         if let Some(recipe) = &self.recipe {
             if self.input_fluid_box.type_ == recipe.input_fluid {
                 self.progress = Some(0.);

--- a/src/steam_engine.rs
+++ b/src/steam_engine.rs
@@ -37,7 +37,7 @@ impl SteamEngine {
                 power_cost: -100.,
                 recipe_time: 100.,
             }),
-            input_fluid_box: FluidBox::new(true, false, [false; 4]),
+            input_fluid_box: FluidBox::new(true, false, [None; 4]),
         }
     }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -89,6 +89,7 @@ impl<'a> StructureDynIter<'a> {
     }
 
     /// Accessor without generation checking.
+    #[allow(dead_code)]
     pub(crate) fn get_at(&self, idx: usize) -> Option<&StructureEntry> {
         if self.left_start <= idx && idx < self.left_start + self.left.len() {
             self.left.get(idx - self.left_start)
@@ -100,6 +101,7 @@ impl<'a> StructureDynIter<'a> {
     }
 
     /// Mutable accessor without generation checking.
+    #[allow(dead_code)]
     pub(crate) fn get_at_mut(&mut self, idx: usize) -> Option<&mut StructureEntry> {
         if self.left_start <= idx && idx < self.left_start + self.left.len() {
             self.left.get_mut(idx - self.left_start)
@@ -111,6 +113,7 @@ impl<'a> StructureDynIter<'a> {
     }
 
     /// Accessor with generation checking.
+    #[allow(dead_code)]
     pub(crate) fn get(&self, id: StructureId) -> Option<&dyn Structure> {
         let idx = id.id as usize;
         if self.left_start <= idx && idx < self.left_start + self.left.len() {
@@ -201,6 +204,7 @@ impl Position {
     }
 
     /// Check whether the positions are neighbors. Return false if they are exactly the same.
+    #[allow(dead_code)]
     pub(crate) fn is_neighbor(&self, pos2: &Position) -> bool {
         [[-1, 0], [0, -1], [1, 0], [0, 1]].iter().any(|rel_pos| {
             let pos = Position {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -35,7 +35,7 @@ macro_rules! draw_fuel_alarm {
     };
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct StructureId {
     pub id: u32,
     pub gen: u32,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -188,7 +188,7 @@ pub(crate) trait Structure {
     fn frame_proc(
         &mut self,
         _state: &mut FactorishState,
-        _structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        _structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         Ok(FrameProcResult::None)
     }

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -35,7 +35,7 @@ macro_rules! draw_fuel_alarm {
     };
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub(crate) struct StructureId {
     pub id: u32,
     pub gen: u32,
@@ -378,6 +378,7 @@ pub(crate) trait Structure {
     }
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         _structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -69,13 +69,13 @@ pub(crate) struct StructureDynIter<'a> {
 }
 
 impl<'a> StructureDynIter<'a> {
-    pub(crate) fn new_all(source: &'a mut [StructureEntry]) -> Result<Self, JsValue> {
-        Ok(Self {
+    pub(crate) fn new_all(source: &'a mut [StructureEntry]) -> Self {
+        Self {
             left_start: 0,
             right_start: source.len(),
             left: source,
             right: &mut [],
-        })
+        }
     }
 
     pub(crate) fn new(

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1,5 +1,5 @@
 use super::{
-    dyn_iter::{DynIter, DynIterDeref, DynIterMut},
+    dyn_iter::{DynIter, DynIterMut},
     items::ItemType,
     water_well::FluidBox,
     DropItem, FactorishState, Inventory, InventoryTrait, Recipe,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -350,7 +350,12 @@ pub(crate) trait Structure {
         Ok(FrameProcResult::None)
     }
     /// event handler for costruction events around the structure.
-    fn on_construction(&mut self, _other: &dyn Structure, _construct: bool) -> Result<(), JsValue> {
+    fn on_construction(
+        &mut self,
+        _other_id: StructureId,
+        _other: &dyn Structure,
+        _construct: bool,
+    ) -> Result<(), JsValue> {
         Ok(())
     }
     /// event handler for costruction events for this structure itself.

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -1,6 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, pipe::Pipe, structure::Structure, FactorishState, FrameProcResult,
-    Position,
+    dyn_iter::DynIterMut,
+    pipe::Pipe,
+    structure::{Structure, StructureId},
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -21,12 +23,16 @@ pub(crate) struct FluidBox {
     pub max_amount: f64,
     pub input_enable: bool,
     pub output_enable: bool,
-    pub connect_to: [bool; 4],
+    pub connect_to: [Option<StructureId>; 4],
     pub filter: Option<FluidType>, // permits undefined
 }
 
 impl FluidBox {
-    pub(crate) fn new(input_enable: bool, output_enable: bool, connect_to: [bool; 4]) -> Self {
+    pub(crate) fn new(
+        input_enable: bool,
+        output_enable: bool,
+        connect_to: [Option<StructureId>; 4],
+    ) -> Self {
         Self {
             type_: None,
             amount: 0.,
@@ -71,7 +77,7 @@ impl FluidBox {
             .connect_to
             .iter()
             .enumerate()
-            .filter(|(_, c)| **c)
+            .filter(|(_, c)| c.is_some())
             .map(|(i, _)| i)
             .collect::<Vec<_>>();
         for i in connect_list {
@@ -143,7 +149,7 @@ impl WaterWell {
     pub(crate) fn new(position: &Position) -> Self {
         WaterWell {
             position: *position,
-            output_fluid_box: FluidBox::new(false, true, [false; 4]).set_type(&FluidType::Water),
+            output_fluid_box: FluidBox::new(false, true, [None; 4]).set_type(&FluidType::Water),
         }
     }
 }

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -1,5 +1,4 @@
 use super::{
-    dyn_iter::DynIterMut,
     pipe::Pipe,
     structure::{Structure, StructureDynIter, StructureId},
     FactorishState, FrameProcResult, Position,
@@ -62,12 +61,7 @@ impl FluidBox {
             )
     }
 
-    pub(crate) fn simulate(
-        &mut self,
-        position: &Position,
-        state: &mut FactorishState,
-        structures: &mut StructureDynIter,
-    ) {
+    pub(crate) fn simulate(&mut self, structures: &mut StructureDynIter) {
         let mut _biggest_flow_idx = -1;
         let mut biggest_flow_amount = 1e-3; // At least this amount of flow is required for displaying flow direction
                                             // In an unlikely event, a fluid box without either input or output ports has nothing to do
@@ -180,14 +174,13 @@ impl Structure for WaterWell {
 
     fn frame_proc(
         &mut self,
-        state: &mut FactorishState,
+        _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         structures.get_mut(StructureId { id: 0, gen: 0 });
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);
-        self.output_fluid_box
-            .simulate(&self.position, state, structures);
+        self.output_fluid_box.simulate(structures);
         Ok(FrameProcResult::None)
     }
 

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -1,7 +1,7 @@
 use super::{
     dyn_iter::DynIterMut,
     pipe::Pipe,
-    structure::{Structure, StructureId},
+    structure::{Structure, StructureDynIter, StructureId},
     FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
@@ -52,11 +52,12 @@ impl FluidBox {
     pub(crate) fn desc(&self) -> String {
         let amount_ratio = self.amount / self.max_amount * 100.;
         // Progress bar
-        format!("{}{}{}",
+        format!("{}{}{}{:?}",
             format!("{}: {:.0}%<br>", self.type_.map(|v| format!("{:?}", v)).unwrap_or_else(|| "None".to_string()), amount_ratio),
             "<div style='position: relative; width: 100px; height: 10px; background-color: #001f1f; margin: 2px; border: 1px solid #3f3f3f'>",
             format!("<div style='position: absolute; width: {}px; height: 10px; background-color: #ff00ff'></div></div>",
                 amount_ratio),
+            self.connect_to,
             )
     }
 
@@ -64,7 +65,7 @@ impl FluidBox {
         &mut self,
         position: &Position,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) {
         let mut _biggest_flow_idx = -1;
         let mut biggest_flow_amount = 1e-3; // At least this amount of flow is required for displaying flow direction
@@ -72,66 +73,56 @@ impl FluidBox {
         if self.amount == 0. || !self.input_enable && !self.output_enable {
             return;
         }
-        let rel_dir = [[-1, 0], [0, -1], [1, 0], [0, 1]];
         let connect_list = self
             .connect_to
             .iter()
             .enumerate()
-            .filter(|(_, c)| c.is_some())
-            .map(|(i, _)| i)
-            .collect::<Vec<_>>();
-        for i in connect_list {
-            let dir_idx = i % 4;
-            let pos = Position {
-                x: position.x + rel_dir[dir_idx][0],
-                y: position.y + rel_dir[dir_idx][1],
-            };
-            if pos.x < 0 || state.width <= pos.x as u32 || pos.y < 0 || state.height <= pos.y as u32
-            {
-                continue;
-            }
-            if let Some(structure) = structures.dyn_iter_mut().find(|s| *s.position() == pos) {
-                let mut process_fluid_box = |self_box: &mut FluidBox, fluid_box: &mut FluidBox| {
+            .filter_map(|(i, c)| Some((i, (*c)?)));
+        for (i, id) in connect_list {
+            console_log!(
+                "water({:?}) fbox[{}]: {:?} real: {:?}",
+                position,
+                i,
+                id,
+                structures.get_at(id.id as usize).map(|i| i.gen)
+            );
+            if let Some(fluid_boxes) = structures.get_mut(id).map(|s| s.fluid_box_mut()).flatten() {
+                for fluid_box in fluid_boxes {
                     // Different types of fluids won't mix
                     if 0. < fluid_box.amount
-                        && 0. < self_box.amount
-                        && fluid_box.type_ != self_box.type_
+                        && 0. < self.amount
+                        && fluid_box.type_ != self.type_
                         && fluid_box.type_.is_some()
                     {
-                        return;
+                        continue;
                     }
-                    let pressure = fluid_box.amount - self_box.amount;
+                    let pressure = fluid_box.amount - self.amount;
                     if 0. < pressure {
-                        return;
+                        continue;
                     }
                     let flow = pressure * 0.1;
                     // Check input/output valve state
                     if if flow < 0. {
-                        !self_box.output_enable
+                        !self.output_enable
                             || !fluid_box.input_enable
-                            || fluid_box.filter.is_some() && fluid_box.filter != self_box.type_
+                            || fluid_box.filter.is_some() && fluid_box.filter != self.type_
                     } else {
-                        !self_box.input_enable
+                        !self.input_enable
                             || !fluid_box.output_enable
-                            || self_box.filter.is_some() && self_box.filter != fluid_box.type_
+                            || self.filter.is_some() && self.filter != fluid_box.type_
                     } {
-                        return;
+                        continue;
                     }
                     fluid_box.amount -= flow;
-                    self_box.amount += flow;
+                    self.amount += flow;
                     if flow < 0. {
-                        fluid_box.type_ = self_box.type_;
+                        fluid_box.type_ = self.type_;
                     } else {
-                        self_box.type_ = fluid_box.type_;
+                        self.type_ = fluid_box.type_;
                     }
                     if biggest_flow_amount < flow.abs() {
                         biggest_flow_amount = flow;
                         _biggest_flow_idx = i as isize;
-                    }
-                };
-                if let Some(fluid_boxes) = structure.fluid_box_mut() {
-                    for fluid_box in fluid_boxes {
-                        process_fluid_box(self, fluid_box);
                     }
                 }
             }
@@ -196,8 +187,9 @@ impl Structure for WaterWell {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = dyn Structure>,
+        structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
+        structures.get_mut(StructureId { id: 0, gen: 0 });
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);
         self.output_fluid_box

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -1,6 +1,8 @@
 use super::{
-    dyn_iter::DynIterMut, pipe::Pipe, structure::Structure, FactorishState, FrameProcResult,
-    Position,
+    dyn_iter::DynIterMut,
+    pipe::Pipe,
+    structure::{Structure, StructureEntry},
+    FactorishState, FrameProcResult, Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -58,7 +60,7 @@ impl FluidBox {
         &mut self,
         position: &Position,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) {
         let mut _biggest_flow_idx = -1;
         let mut biggest_flow_amount = 1e-3; // At least this amount of flow is required for displaying flow direction
@@ -84,7 +86,11 @@ impl FluidBox {
             {
                 continue;
             }
-            if let Some(structure) = structures.dyn_iter_mut().find(|s| *s.position() == pos) {
+            if let Some(structure) = structures
+                .dyn_iter_mut()
+                .filter_map(|s| s.dynamic.as_deref_mut())
+                .find(|s| *s.position() == pos)
+            {
                 let mut process_fluid_box = |self_box: &mut FluidBox, fluid_box: &mut FluidBox| {
                     // Different types of fluids won't mix
                     if 0. < fluid_box.amount
@@ -190,7 +196,7 @@ impl Structure for WaterWell {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = Box<dyn Structure>>,
+        structures: &mut dyn DynIterMut<Item = StructureEntry>,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -1,8 +1,6 @@
 use super::{
-    dyn_iter::DynIterMut,
-    pipe::Pipe,
-    structure::{Structure, StructureEntry},
-    FactorishState, FrameProcResult, Position,
+    dyn_iter::DynIterMut, pipe::Pipe, structure::Structure, FactorishState, FrameProcResult,
+    Position,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -60,7 +58,7 @@ impl FluidBox {
         &mut self,
         position: &Position,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) {
         let mut _biggest_flow_idx = -1;
         let mut biggest_flow_amount = 1e-3; // At least this amount of flow is required for displaying flow direction
@@ -86,11 +84,7 @@ impl FluidBox {
             {
                 continue;
             }
-            if let Some(structure) = structures
-                .dyn_iter_mut()
-                .filter_map(|s| s.dynamic.as_deref_mut())
-                .find(|s| *s.position() == pos)
-            {
+            if let Some(structure) = structures.dyn_iter_mut().find(|s| *s.position() == pos) {
                 let mut process_fluid_box = |self_box: &mut FluidBox, fluid_box: &mut FluidBox| {
                     // Different types of fluids won't mix
                     if 0. < fluid_box.amount
@@ -196,7 +190,7 @@ impl Structure for WaterWell {
     fn frame_proc(
         &mut self,
         state: &mut FactorishState,
-        structures: &mut dyn DynIterMut<Item = StructureEntry>,
+        structures: &mut dyn DynIterMut<Item = dyn Structure>,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
             (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -23,6 +23,7 @@ pub(crate) struct FluidBox {
     pub max_amount: f64,
     pub input_enable: bool,
     pub output_enable: bool,
+    #[serde(skip)]
     pub connect_to: [Option<StructureId>; 4],
     pub filter: Option<FluidType>, // permits undefined
 }
@@ -79,13 +80,6 @@ impl FluidBox {
             .enumerate()
             .filter_map(|(i, c)| Some((i, (*c)?)));
         for (i, id) in connect_list {
-            console_log!(
-                "water({:?}) fbox[{}]: {:?} real: {:?}",
-                position,
-                i,
-                id,
-                structures.get_at(id.id as usize).map(|i| i.gen)
-            );
             if let Some(fluid_boxes) = structures.get_mut(id).map(|s| s.fluid_box_mut()).flatten() {
                 for fluid_box in fluid_boxes {
                     // Different types of fluids won't mix

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -174,6 +174,7 @@ impl Structure for WaterWell {
 
     fn frame_proc(
         &mut self,
+        _me: StructureId,
         _state: &mut FactorishState,
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {

--- a/static/index.html
+++ b/static/index.html
@@ -236,8 +236,9 @@
 			</div>
 			<div id="viewContainer" class="params" style="display: none;">
 				<div style="font-size: 120%; font-weight: 700">View settings</div>
-				<label><input type="checkbox" id="showDebugBBox">Show Debug Bounding Box</label>
-				<label><input type="checkbox" id="showDebugFluidBox">Show Debug Fluid Box</label>
+				<div><label><input type="checkbox" id="showDebugBBox">Show Debug Bounding Box</label></div>
+				<div><label><input type="checkbox" id="showDebugFluidBox">Show Debug Fluid Box</label></div>
+				<div><label><input type="checkbox" id="showDebugPowerNetwork">Show Debug Power Network</label></div>
 			</div>
 		</div>
 		<hr>


### PR DESCRIPTION
Generational IDs enable stable index in Structure list that can be automatically invalidated when a Structure expires. It improves the performance of logics that need stable relationships between structures greatly.