### PR TITLE
Fixes #15 Use generational ids for DropItems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ features = [
     'ImageData',
     'Window',
     'Storage',
+    'Performance', 'PerformanceTiming'
 ]
 
 [package.metadata.wasm-pack.profile.release]

--- a/js/main.js
+++ b/js/main.js
@@ -1268,7 +1268,7 @@ let ysize = 128;
         sim.render_minimap(miniMapContext);
 
         if(showPerfGraph.checked){
-            const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00"];
+            const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00", "#ff00ff"];
             while(perfLabel.firstChild) perfLabel.removeChild(perfLabel.firstChild);
             sim.render_perf(perfContext).forEach((text, idx) => {
                 const elem = document.createElement("div");

--- a/js/main.js
+++ b/js/main.js
@@ -313,7 +313,7 @@ let ysize = 128;
     perfLabel.style.left = '8px';
     perfLabel.style.bottom = '216px';
     perfLabel.style.padding = "4px";
-    perfLabel.style.backgroundColor = "rgba(191, 191, 191, 0.75)";
+    perfLabel.style.backgroundColor = "rgba(0, 0, 0, 0.75)";
     container.appendChild(perfLabel);
 
     refreshSize();
@@ -1268,7 +1268,7 @@ let ysize = 128;
         sim.render_minimap(miniMapContext);
 
         if(showPerfGraph.checked){
-            const colors = ["#000", "#ff0000", "#0000ff"];
+            const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00"];
             while(perfLabel.firstChild) perfLabel.removeChild(perfLabel.firstChild);
             sim.render_perf(perfContext).forEach((text, idx) => {
                 const elem = document.createElement("div");

--- a/js/main.js
+++ b/js/main.js
@@ -1268,7 +1268,7 @@ let ysize = 128;
         sim.render_minimap(miniMapContext);
 
         if(showPerfGraph.checked){
-            const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00", "#ff00ff"];
+            const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00", "#ff00ff", "#fff"];
             while(perfLabel.firstChild) perfLabel.removeChild(perfLabel.firstChild);
             sim.render_perf(perfContext).forEach((text, idx) => {
                 const elem = document.createElement("div");

--- a/js/main.js
+++ b/js/main.js
@@ -290,6 +290,31 @@ let ysize = 128;
 
     infoElem.style.textAlign = 'left';
 
+    const perfWidth = 200;
+    const perfHeight = 200;
+    const perfElem = document.createElement('canvas');
+    perfElem.style.position = 'absolute';
+    perfElem.style.pointerEvents = "none";
+    perfElem.style.border = '1px solid #000';
+    perfElem.setAttribute("width", perfWidth);
+    perfElem.setAttribute("height", perfHeight);
+    perfElem.style.width = perfWidth + 'px';
+    perfElem.style.height = perfHeight + 'px';
+    perfElem.style.left = '8px';
+    perfElem.style.bottom = '8px';
+    perfElem.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
+    container.appendChild(perfElem);
+    const perfContext = perfElem.getContext('2d');
+
+    const perfLabel = document.createElement('div');
+    perfLabel.style.position = 'absolute';
+    perfLabel.style.pointerEvents = "none";
+    perfLabel.style.left = '8px';
+    perfLabel.style.bottom = '216px';
+    perfLabel.style.padding = "4px";
+    perfLabel.style.backgroundColor = "rgba(191, 191, 191, 0.75)";
+    container.appendChild(perfLabel);
+
     refreshSize();
 
     const toolBeltSize = 10;
@@ -1219,6 +1244,15 @@ let ysize = 128;
     showDebugFluidBox.addEventListener("click", () => sim.set_debug_fluidbox(showDebugFluidBox.checked));
     const showDebugPowerNetwork = document.getElementById("showDebugPowerNetwork");
     showDebugPowerNetwork.addEventListener("click", () => sim.set_debug_power_network(showDebugPowerNetwork.checked));
+    const showPerfGraph = document.getElementById("showPerfGraph");
+    showPerfGraph.addEventListener("click", updatePerfVisibility);
+
+    function updatePerfVisibility() {
+        perfElem.style.display = showPerfGraph.checked ? "block" : "none";
+        perfLabel.style.display = showPerfGraph.checked ? "block" : "none";
+    }
+
+    updatePerfVisibility();
 
     window.setInterval(function(){
         if(!paused)
@@ -1231,6 +1265,11 @@ let ysize = 128;
         }
 
         sim.render_minimap(miniMapContext);
+
+        if(showPerfGraph.checked){
+            const maxVal = sim.render_perf(perfContext);
+            perfLabel.innerHTML = maxVal;
+        }
         // console.log(result);
     }, 50);
     // simulate()

--- a/js/main.js
+++ b/js/main.js
@@ -309,6 +309,7 @@ let ysize = 128;
     const perfLabel = document.createElement('div');
     perfLabel.style.position = 'absolute';
     perfLabel.style.pointerEvents = "none";
+    perfLabel.style.textAlign = "justify";
     perfLabel.style.left = '8px';
     perfLabel.style.bottom = '216px';
     perfLabel.style.padding = "4px";
@@ -1267,8 +1268,14 @@ let ysize = 128;
         sim.render_minimap(miniMapContext);
 
         if(showPerfGraph.checked){
-            const maxVal = sim.render_perf(perfContext);
-            perfLabel.innerHTML = maxVal;
+            const colors = ["#000", "#ff0000", "#0000ff"];
+            while(perfLabel.firstChild) perfLabel.removeChild(perfLabel.firstChild);
+            sim.render_perf(perfContext).forEach((text, idx) => {
+                const elem = document.createElement("div");
+                elem.innerHTML = text;
+                elem.style.color = colors[idx % colors.length];
+                perfLabel.appendChild(elem);
+            });
         }
         // console.log(result);
     }, 50);

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,9 +1,10 @@
 use super::{
+    drop_items::DropItem,
     inventory::{Inventory, InventoryTrait},
     items::get_item_image_url,
     serialize_impl,
     structure::{Structure, StructureDynIter, StructureId},
-    DropItem, FactorishState, FrameProcResult, ItemType, Position, Recipe, TILE_SIZE,
+    FactorishState, FrameProcResult, ItemType, Position, Recipe, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -1,9 +1,9 @@
 use super::{
+    inventory::{Inventory, InventoryTrait},
     items::get_item_image_url,
     serialize_impl,
     structure::{Structure, StructureDynIter, StructureId},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
-    Recipe, TILE_SIZE,
+    DropItem, FactorishState, FrameProcResult, ItemType, Position, Recipe, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/src/boiler.rs
+++ b/src/boiler.rs
@@ -1,10 +1,11 @@
 use super::pipe::Pipe;
 use super::{
+    drop_items::DropItem,
     serialize_impl,
     structure::{Structure, StructureDynIter, StructureId},
     water_well::{FluidBox, FluidType},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position,
-    Recipe, TempEnt, COAL_POWER,
+    FactorishState, FrameProcResult, Inventory, InventoryTrait, ItemType, Position, Recipe,
+    TempEnt, COAL_POWER,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/src/chest.rs
+++ b/src/chest.rs
@@ -1,6 +1,9 @@
-use super::items::{DropItem, ItemType};
-use super::structure::{ItemResponse, ItemResponseResult, Structure};
-use super::{FactorishState, FrameProcResult, Inventory, InventoryTrait, Position};
+use super::{
+    drop_items::DropItem,
+    items::ItemType,
+    structure::{ItemResponse, ItemResponseResult, Structure},
+    FactorishState, FrameProcResult, Inventory, InventoryTrait, Position,
+};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use web_sys::CanvasRenderingContext2d;

--- a/src/drop_items.rs
+++ b/src/drop_items.rs
@@ -1,0 +1,256 @@
+use super::{dyn_iter::DynIter, items::ItemType, Position, TILE_SIZE_I};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+pub(crate) const DROP_ITEM_SIZE: f64 = 8.;
+pub(crate) const DROP_ITEM_SIZE_I: i32 = DROP_ITEM_SIZE as i32;
+
+pub(crate) type DropItemId = GenId;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct DropItem {
+    pub type_: ItemType,
+    pub x: i32,
+    pub y: i32,
+}
+
+impl DropItem {
+    pub(crate) fn new(type_: ItemType, c: i32, r: i32) -> Self {
+        let ret = DropItem {
+            type_,
+            x: c * TILE_SIZE_I + TILE_SIZE_I / 2,
+            y: r * TILE_SIZE_I + TILE_SIZE_I / 2,
+        };
+        ret
+    }
+}
+
+pub(crate) type DropItemEntry = GenEntry<DropItem>;
+
+impl DropItemEntry {
+    pub(crate) fn new(type_: ItemType, position: &Position) -> Self {
+        Self {
+            gen: 0,
+            item: Some(DropItem::new(type_, position.x, position.y)),
+        }
+    }
+
+    pub(crate) fn from_value(value: DropItem) -> Self {
+        Self {
+            gen: 0,
+            item: Some(value),
+        }
+    }
+}
+
+/// Returns an iterator over valid structures
+pub(crate) fn drop_item_id_iter(
+    drop_items: &[DropItemEntry],
+) -> impl Iterator<Item = (DropItemId, &DropItem)> {
+    drop_items.iter().enumerate().filter_map(|(id, item)| {
+        Some((
+            DropItemId {
+                id: id as u32,
+                gen: item.gen,
+            },
+            item.item.as_ref()?,
+        ))
+    })
+}
+
+/// Returns an iterator over valid structures
+pub(crate) fn drop_item_id_iter_mut(
+    drop_items: &mut [DropItemEntry],
+) -> impl Iterator<Item = (DropItemId, &mut DropItem)> {
+    drop_items.iter_mut().enumerate().filter_map(|(id, item)| {
+        Some((
+            DropItemId {
+                id: id as u32,
+                gen: item.gen,
+            },
+            item.item.as_mut()?,
+        ))
+    })
+}
+
+/// Returns an iterator over valid structures
+pub(crate) fn drop_item_iter(drop_items: &[DropItemEntry]) -> impl Iterator<Item = &DropItem> {
+    drop_items
+        .iter()
+        .filter_map(|item| Some(item.item.as_ref()?))
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub(crate) struct GenId {
+    pub id: u32,
+    pub gen: u32,
+}
+
+impl GenId {
+    pub(crate) fn new(id: u32, gen: u32) -> Self {
+        Self { id, gen }
+    }
+}
+
+pub(crate) struct GenEntry<T> {
+    pub gen: u32,
+    pub item: Option<T>,
+}
+
+/// A structure that allow random access to structure array excluding single element.
+/// It is convenient when you want to have mutable reference to two elements in the array at the same time.
+pub(crate) struct SplitSlice<'a, T> {
+    left_start: usize,
+    left: &'a mut [GenEntry<T>],
+    right_start: usize,
+    right: &'a mut [GenEntry<T>],
+}
+
+impl<'a, T> SplitSlice<'a, T> {
+    #[allow(dead_code)]
+    pub(crate) fn new_all(source: &'a mut [GenEntry<T>]) -> Self {
+        Self {
+            left_start: 0,
+            right_start: source.len(),
+            left: source,
+            right: &mut [],
+        }
+    }
+
+    pub(crate) fn new(
+        source: &'a mut [GenEntry<T>],
+        split_idx: usize,
+    ) -> Result<(&'a mut GenEntry<T>, Self), JsValue> {
+        let (left, right) = source.split_at_mut(split_idx);
+        let (center, right) = right
+            .split_first_mut()
+            .ok_or_else(|| JsValue::from_str("Structures split fail"))?;
+        Ok((
+            center,
+            Self {
+                left_start: 0,
+                left,
+                right_start: split_idx + 1,
+                right,
+            },
+        ))
+    }
+
+    /// Accessor without generation checking.
+    #[allow(dead_code)]
+    pub(crate) fn get_at(&self, idx: usize) -> Option<&GenEntry<T>> {
+        if self.left_start <= idx && idx < self.left_start + self.left.len() {
+            self.left.get(idx - self.left_start)
+        } else if self.right_start <= idx && idx < self.right_start + self.right.len() {
+            self.right.get(idx - self.right_start)
+        } else {
+            None
+        }
+    }
+
+    /// Mutable accessor without generation checking.
+    #[allow(dead_code)]
+    pub(crate) fn get_at_mut(&mut self, idx: usize) -> Option<&mut GenEntry<T>> {
+        if self.left_start <= idx && idx < self.left_start + self.left.len() {
+            self.left.get_mut(idx - self.left_start)
+        } else if self.right_start <= idx && idx < self.right_start + self.right.len() {
+            self.right.get_mut(idx - self.right_start)
+        } else {
+            None
+        }
+    }
+
+    /// Accessor with generation checking.
+    #[allow(dead_code)]
+    pub(crate) fn get(&self, id: GenId) -> Option<&T> {
+        let idx = id.id as usize;
+        if self.left_start <= idx && idx < self.left_start + self.left.len() {
+            self.left
+                .get(idx - self.left_start)
+                .filter(|s| s.gen == id.gen)
+                .map(|s| s.item.as_ref())
+                .flatten()
+        } else if self.right_start <= idx && idx < self.right_start + self.right.len() {
+            self.right
+                .get(idx - self.right_start)
+                .filter(|s| s.gen == id.gen)
+                .map(|s| s.item.as_ref())
+                .flatten()
+        } else {
+            None
+        }
+    }
+
+    /// Mutable accessor with generation checking.
+    #[allow(dead_code)]
+    pub(crate) fn get_mut(&mut self, id: GenId) -> Option<&mut T> {
+        let idx = id.id as usize;
+        if self.left_start <= idx && idx < self.left_start + self.left.len() {
+            self.left
+                .get_mut(idx - self.left_start)
+                .filter(|s| s.gen == id.gen)
+                .map(|s| s.item.as_mut())
+                // Interestingly, we need .map(|s| s as &mut dyn Structure) to compile.
+                // .map(|s| s.item.as_deref_mut())
+                .flatten()
+        } else if self.right_start <= idx && idx < self.right_start + self.right.len() {
+            self.right
+                .get_mut(idx - self.right_start)
+                .filter(|s| s.gen == id.gen)
+                .map(|s| s.item.as_mut())
+                // .map(|s| s.item.as_deref_mut())
+                .flatten()
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn dyn_iter_id(&self) -> impl Iterator<Item = (GenId, &T)> + '_ {
+        self.left
+            .iter()
+            .enumerate()
+            .map(move |(i, val)| (GenId::new((i + self.left_start) as u32, val.gen), val))
+            .chain(
+                self.right
+                    .iter()
+                    .enumerate()
+                    .map(move |(i, val)| (GenId::new((i + self.right_start) as u32, val.gen), val)),
+            )
+            .filter_map(|(i, s)| Some((i, s.item.as_ref()?)))
+    }
+}
+
+impl<'a, T> DynIter for SplitSlice<'a, T> {
+    type Item = T;
+    fn dyn_iter(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_> {
+        Box::new(
+            self.left
+                .iter()
+                .chain(self.right.iter())
+                .filter_map(|s| s.item.as_ref()),
+        )
+    }
+    fn as_dyn_iter(&self) -> &dyn DynIter<Item = Self::Item> {
+        self
+    }
+}
+
+/// Check whether given coordinates hits some object
+pub(crate) fn hit_check<'a>(
+    iter: impl Iterator<Item = (DropItemId, &'a DropItem)>,
+    x: i32,
+    y: i32,
+    ignore: Option<DropItemId>,
+) -> bool {
+    for (id, item) in iter {
+        if let Some(ignore_id) = ignore {
+            if ignore_id == id {
+                continue;
+            }
+        }
+        if (x - item.x).abs() < DROP_ITEM_SIZE_I && (y - item.y).abs() < DROP_ITEM_SIZE_I {
+            return true;
+        }
+    }
+    false
+}

--- a/src/drop_items.rs
+++ b/src/drop_items.rs
@@ -236,20 +236,23 @@ impl<'a, T> DynIter for SplitSlice<'a, T> {
 }
 
 /// Check whether given coordinates hits some object
-pub(crate) fn hit_check<'a>(
-    iter: impl Iterator<Item = (DropItemId, &'a DropItem)>,
+pub(crate) fn hit_check(
+    items: &[DropItemEntry],
     x: i32,
     y: i32,
     ignore: Option<DropItemId>,
 ) -> bool {
-    for (id, item) in iter {
-        if let Some(ignore_id) = ignore {
-            if ignore_id == id {
-                continue;
+    for (id, entry) in items.iter().enumerate() {
+        if let Some(item) = entry.item.as_ref() {
+            if let Some(ignore_id) = ignore {
+                let id = DropItemId::new(id as u32, entry.gen);
+                if ignore_id == id {
+                    continue;
+                }
             }
-        }
-        if (x - item.x).abs() < DROP_ITEM_SIZE_I && (y - item.y).abs() < DROP_ITEM_SIZE_I {
-            return true;
+            if (x - item.x).abs() < DROP_ITEM_SIZE_I && (y - item.y).abs() < DROP_ITEM_SIZE_I {
+                return true;
+            }
         }
     }
     false

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,8 +1,9 @@
 use super::{
     draw_direction_arrow,
+    drop_items::DropItem,
     items::{render_drop_item, ItemType},
     structure::{RotateErr, Structure, StructureDynIter, StructureId},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
+    FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Rotation,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -196,7 +197,7 @@ impl Structure for Inserter {
                 };
 
                 let mut lets_try_hold = None;
-                if let Some(&DropItem { type_, id, .. }) = state.find_item(&input_position) {
+                if let Some((id, &DropItem { type_, .. })) = state.find_item(&input_position) {
                     if try_hold(structures, type_) {
                         state.remove_item(id);
                     } else {
@@ -293,7 +294,6 @@ impl Structure for Inserter {
                 {
                     if structure
                         .input(&DropItem::new(
-                            &mut state.serial_no,
                             item_type,
                             output_position.x,
                             output_position.y,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,0 +1,77 @@
+use super::ItemType;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, convert::TryFrom};
+use wasm_bindgen::prelude::*;
+
+pub(crate) type Inventory = HashMap<ItemType, usize>;
+
+pub(crate) trait InventoryTrait {
+    fn remove_item(&mut self, item: &ItemType) -> bool {
+        self.remove_items(item, 1)
+    }
+    fn remove_items(&mut self, item: &ItemType, count: usize) -> bool;
+    fn add_item(&mut self, item: &ItemType) {
+        self.add_items(item, 1);
+    }
+    fn add_items(&mut self, item: &ItemType, count: usize);
+    fn count_item(&self, item: &ItemType) -> usize;
+    fn merge(&mut self, other: Inventory);
+    fn describe(&self) -> String;
+}
+
+impl InventoryTrait for Inventory {
+    fn remove_items(&mut self, item: &ItemType, count: usize) -> bool {
+        if let Some(entry) = self.get_mut(item) {
+            if *entry <= count {
+                self.remove(item);
+            } else {
+                *entry -= count;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn add_items(&mut self, item: &ItemType, count: usize) {
+        if let Some(entry) = self.get_mut(item) {
+            *entry += count;
+        } else {
+            self.insert(*item, count);
+        }
+    }
+
+    fn count_item(&self, item: &ItemType) -> usize {
+        *self.get(item).unwrap_or(&0)
+    }
+
+    fn merge(&mut self, other: Inventory) {
+        for (k, v) in other {
+            if let Some(vv) = self.get_mut(&k) {
+                *vv += v;
+            } else {
+                self.insert(k, v);
+            }
+        }
+    }
+
+    fn describe(&self) -> String {
+        self.iter()
+            .map(|item| format!("{:?}: {}<br>", item.0, item.1))
+            .fold(String::from(""), |accum, item| accum + &item)
+    }
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+pub(crate) enum InventoryType {
+    Input,
+    Output,
+    Burner,
+}
+
+impl TryFrom<JsValue> for InventoryType {
+    type Error = JsValue;
+    fn try_from(value: JsValue) -> Result<Self, JsValue> {
+        value.into_serde().map_err(|e| js_str!("{}", e.to_string()))
+    }
+}

--- a/src/items.rs
+++ b/src/items.rs
@@ -1,4 +1,4 @@
-use super::{tilesize, FactorishState, ImageBundle};
+use super::{FactorishState, ImageBundle};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use web_sys::CanvasRenderingContext2d;
@@ -85,28 +85,6 @@ pub(crate) fn str_to_item(name: &str) -> Option<ItemType> {
         "Splitter" => Some(ItemType::Splitter),
 
         _ => None,
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub(crate) struct DropItem {
-    pub id: u32,
-    pub type_: ItemType,
-    pub x: i32,
-    pub y: i32,
-}
-
-impl DropItem {
-    pub(crate) fn new(serial_no: &mut u32, type_: ItemType, c: i32, r: i32) -> Self {
-        let itilesize = tilesize as i32;
-        let ret = DropItem {
-            id: *serial_no,
-            type_,
-            x: c * itilesize + itilesize / 2,
-            y: r * itilesize + itilesize / 2,
-        };
-        *serial_no += 1;
-        ret
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod water_well;
 
 use crate::drop_items::{
     build_index, drop_item_id_iter, drop_item_iter, hit_check, hit_check_with_index, DropItem,
-    DropItemEntry, DropItemId, SplitSlice, DROP_ITEM_SIZE, INDEX_CHUNK_SIZE,
+    DropItemEntry, DropItemId, DROP_ITEM_SIZE, INDEX_CHUNK_SIZE,
 };
 use crate::{
     scenarios::select_scenario,
@@ -1151,8 +1151,7 @@ impl FactorishState {
             }
         }
 
-        let index = drop_items::build_index(&self.drop_items);
-        console_log!("Index: {}: {:?}", index.len(), drop_items::hist(&index));
+        let index = build_index(&self.drop_items);
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
             let entry = &self.drop_items[i];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,45 +1,8 @@
 #![allow(non_upper_case_globals)]
 
-macro_rules! console_log {
-    ($fmt:expr, $($arg1:expr),*) => {
-        crate::log(&format!($fmt, $($arg1),+))
-    };
-    ($fmt:expr) => {
-        crate::log($fmt)
-    }
-}
-
-/// format-like macro that returns js_sys::String
-macro_rules! js_str {
-    ($fmt:expr, $($arg1:expr),*) => {
-        JsValue::from_str(&format!($fmt, $($arg1),+))
-    };
-    ($fmt:expr) => {
-        JsValue::from_str($fmt)
-    }
-}
-
-/// format-like macro that returns Err(js_sys::String)
-macro_rules! js_err {
-    ($fmt:expr, $($arg1:expr),*) => {
-        Err(JsValue::from_str(&format!($fmt, $($arg1),+)))
-    };
-    ($fmt:expr) => {
-        Err(JsValue::from_str($fmt))
-    }
-}
-
-macro_rules! hash_map {
-    { $($key:expr => $value:expr),+ } => {
-        {
-            let mut m = ::std::collections::HashMap::new();
-            $(
-                m.insert($key, $value);
-            )+
-            m
-        }
-    };
-}
+/// Macros needs to come first
+#[macro_use]
+mod macros;
 
 mod assembler;
 mod boiler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ mod utils;
 mod water_well;
 
 use crate::drop_items::{
-    drop_item_id_iter, drop_item_iter, hit_check, DropItem, DropItemEntry, DropItemId, SplitSlice,
-    DROP_ITEM_SIZE,
+    build_index, drop_item_id_iter, drop_item_iter, hit_check, hit_check_with_index, DropItem,
+    DropItemEntry, DropItemId, SplitSlice, DROP_ITEM_SIZE,
 };
 use crate::{
     scenarios::select_scenario,
@@ -1151,6 +1151,8 @@ impl FactorishState {
             }
         }
 
+        let index = drop_items::build_index(&self.drop_items);
+        console_log!("Index: {}", index.len());
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
             let entry = &self.drop_items[i];
@@ -1178,7 +1180,13 @@ impl FactorishState {
                 {
                     match item_response_result.0 {
                         ItemResponse::Move(moved_x, moved_y) => {
-                            if hit_check(&self.drop_items, moved_x, moved_y, Some(id)) {
+                            if hit_check_with_index(
+                                &self.drop_items,
+                                &index,
+                                moved_x,
+                                moved_y,
+                                Some(id),
+                            ) {
                                 continue;
                             }
                             let position = Position {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_upper_case_globals)]
 
-/// Macros needs to come first
+/// Macros needs to come first in order to be accessible from all the codes
 #[macro_use]
 mod macros;
 
@@ -11,6 +11,7 @@ mod dyn_iter;
 mod elect_pole;
 mod furnace;
 mod inserter;
+mod inventory;
 mod items;
 mod offshore_pump;
 mod ore_mine;
@@ -37,6 +38,7 @@ use dyn_iter::{Chained, DynIterMut, MutRef};
 use elect_pole::ElectPole;
 use furnace::Furnace;
 use inserter::Inserter;
+use inventory::{Inventory, InventoryTrait, InventoryType};
 use items::{item_to_str, render_drop_item, str_to_item, DropItem, ItemType};
 use offshore_pump::OffshorePump;
 use ore_mine::OreMine;
@@ -169,79 +171,6 @@ impl Cell {
             Some(OreValue(Ore::Stone, _)) => Some(ItemType::StoneOre),
             _ => None,
         }
-    }
-}
-
-type Inventory = HashMap<ItemType, usize>;
-
-trait InventoryTrait {
-    fn remove_item(&mut self, item: &ItemType) -> bool {
-        self.remove_items(item, 1)
-    }
-    fn remove_items(&mut self, item: &ItemType, count: usize) -> bool;
-    fn add_item(&mut self, item: &ItemType) {
-        self.add_items(item, 1);
-    }
-    fn add_items(&mut self, item: &ItemType, count: usize);
-    fn count_item(&self, item: &ItemType) -> usize;
-    fn merge(&mut self, other: Inventory);
-    fn describe(&self) -> String;
-}
-
-impl InventoryTrait for Inventory {
-    fn remove_items(&mut self, item: &ItemType, count: usize) -> bool {
-        if let Some(entry) = self.get_mut(item) {
-            if *entry <= count {
-                self.remove(item);
-            } else {
-                *entry -= count;
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    fn add_items(&mut self, item: &ItemType, count: usize) {
-        if let Some(entry) = self.get_mut(item) {
-            *entry += count;
-        } else {
-            self.insert(*item, count);
-        }
-    }
-
-    fn count_item(&self, item: &ItemType) -> usize {
-        *self.get(item).unwrap_or(&0)
-    }
-
-    fn merge(&mut self, other: Inventory) {
-        for (k, v) in other {
-            if let Some(vv) = self.get_mut(&k) {
-                *vv += v;
-            } else {
-                self.insert(k, v);
-            }
-        }
-    }
-
-    fn describe(&self) -> String {
-        self.iter()
-            .map(|item| format!("{:?}: {}<br>", item.0, item.1))
-            .fold(String::from(""), |accum, item| accum + &item)
-    }
-}
-
-#[derive(PartialEq, Debug, Serialize, Deserialize)]
-enum InventoryType {
-    Input,
-    Output,
-    Burner,
-}
-
-impl TryFrom<JsValue> for InventoryType {
-    type Error = JsValue;
-    fn try_from(value: JsValue) -> Result<Self, JsValue> {
-        value.into_serde().map_err(|e| js_str!("{}", e.to_string()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,7 @@ pub struct FactorishState {
     perf_drop_items: PerfStats,
     perf_simulate: PerfStats,
     perf_minimap: PerfStats,
+    perf_render: PerfStats,
 
     // on_show_inventory: js_sys::Function,
     image_dirt: Option<ImageBundle>,
@@ -563,6 +564,7 @@ impl FactorishState {
             perf_drop_items: PerfStats::default(),
             perf_simulate: PerfStats::default(),
             perf_minimap: PerfStats::default(),
+            perf_render: PerfStats::default(),
             image_dirt: None,
             image_back_tiles: None,
             image_weeds: None,
@@ -2575,8 +2577,10 @@ impl FactorishState {
         self.structures.iter().filter_map(|s| s.dynamic.as_deref())
     }
 
-    pub fn render(&self, context: CanvasRenderingContext2d) -> Result<(), JsValue> {
+    pub fn render(&mut self, context: CanvasRenderingContext2d) -> Result<(), JsValue> {
         use std::f64;
+
+        let start_render = performance().now();
 
         context.clear_rect(0., 0., self.viewport_width, self.viewport_height);
 
@@ -2851,6 +2855,7 @@ impl FactorishState {
             context.fill_text(&item.text, item.x, item.y)?;
         }
 
+        self.perf_render.add(performance().now() - start_render);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1154,8 +1154,8 @@ impl FactorishState {
         let mut to_remove = vec![];
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
-            let (entry, others) = SplitSlice::new(&mut self.drop_items, i)?;
-            let item = if let Some(item) = entry.item.as_mut() {
+            let entry = &self.drop_items[i];
+            let item = if let Some(item) = entry.item.as_ref() {
                 item
             } else {
                 continue;
@@ -1179,7 +1179,7 @@ impl FactorishState {
                 {
                     match item_response_result.0 {
                         ItemResponse::Move(moved_x, moved_y) => {
-                            if hit_check(others.dyn_iter_id(), moved_x, moved_y, Some(id)) {
+                            if hit_check(&self.drop_items, moved_x, moved_y, Some(id)) {
                                 continue;
                             }
                             let position = Position {
@@ -1197,6 +1197,7 @@ impl FactorishState {
                             } else {
                                 continue;
                             }
+                            let item = self.drop_items[i].item.as_mut().unwrap();
                             item.x = moved_x;
                             item.y = moved_y;
                         }
@@ -1381,7 +1382,7 @@ impl FactorishState {
             }
             let item = DropItem::new(type_, pos.x, pos.y);
             // return board[c + r * ysize].structure.input(obj);
-            if hit_check(drop_item_id_iter(&self.drop_items), item.x, item.y, None) {
+            if hit_check(&self.drop_items, item.x, item.y, None) {
                 return Err(NewObjectErr::BlockedByItem);
             }
             // obj.addElem();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1151,7 +1151,6 @@ impl FactorishState {
             }
         }
 
-        let mut to_remove = vec![];
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
             let entry = &self.drop_items[i];
@@ -1202,7 +1201,7 @@ impl FactorishState {
                             item.y = moved_y;
                         }
                         ItemResponse::Consume => {
-                            to_remove.push(id);
+                            self.drop_items[i].item = None;
                         }
                     }
                     if let Some(result) = item_response_result.1 {
@@ -1210,10 +1209,6 @@ impl FactorishState {
                     }
                 }
             }
-        }
-
-        for id in to_remove {
-            self.remove_item(id);
         }
 
         self.structures = structures;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,7 @@ pub struct FactorishState {
     // Performance measurements
     perf_build_index: PerfStats,
     perf_drop_items: PerfStats,
+    perf_simulate: PerfStats,
 
     // on_show_inventory: js_sys::Function,
     image_dirt: Option<ImageBundle>,
@@ -559,6 +560,7 @@ impl FactorishState {
             debug_power_network: false,
             perf_build_index: PerfStats::default(),
             perf_drop_items: PerfStats::default(),
+            perf_simulate: PerfStats::default(),
             image_dirt: None,
             image_back_tiles: None,
             image_weeds: None,
@@ -1065,6 +1067,7 @@ impl FactorishState {
     }
 
     pub fn simulate(&mut self, delta_time: f64) -> Result<js_sys::Array, JsValue> {
+        let start_simulate = performance().now();
         // console_log!("simulating delta_time {}, {}", delta_time, self.sim_time);
         const SERIALIZE_PERIOD: f64 = 100.;
         if (self.sim_time / SERIALIZE_PERIOD).floor()
@@ -1250,6 +1253,8 @@ impl FactorishState {
             })
             .filter(|ent| 0. < ent.life)
             .collect();
+
+        self.perf_simulate.add(performance().now() - start_simulate);
 
         // self.drop_items = drop_items;
         self.update_info();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2712,8 +2712,8 @@ impl FactorishState {
                 );
             }
             context.set_stroke_style(&js_str!("black"));
-            for y in 0..self.height / INDEX_CHUNK_SIZE {
-                for x in 0..self.width / INDEX_CHUNK_SIZE {
+            for y in 0..self.height / INDEX_CHUNK_SIZE as u32 {
+                for x in 0..self.width / INDEX_CHUNK_SIZE as u32 {
                     context.stroke_rect(
                         x as f64 * TILE_SIZE * INDEX_CHUNK_SIZE as f64,
                         y as f64 * TILE_SIZE * INDEX_CHUNK_SIZE as f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ pub struct FactorishState {
     debug_power_network: bool,
 
     // Performance measurements
-    perf_build_index: PerfStats,
+    perf_structures: PerfStats,
     perf_drop_items: PerfStats,
     perf_simulate: PerfStats,
     perf_minimap: PerfStats,
@@ -562,7 +562,7 @@ impl FactorishState {
             debug_bbox: false,
             debug_fluidbox: false,
             debug_power_network: false,
-            perf_build_index: PerfStats::default(),
+            perf_structures: PerfStats::default(),
             perf_drop_items: PerfStats::default(),
             perf_simulate: PerfStats::default(),
             perf_minimap: PerfStats::default(),
@@ -1158,6 +1158,7 @@ impl FactorishState {
             self.popup_texts.remove(*i);
         }
 
+        let start_structures = performance().now();
         // This is silly way to avoid borrow checker that temporarily move the structures
         // away from self so that they do not claim mutable borrow twice, but it works.
         let mut structures = std::mem::take(&mut self.structures);
@@ -1176,10 +1177,11 @@ impl FactorishState {
                 );
             }
         }
+        self.perf_structures
+            .add(performance().now() - start_structures);
 
         let start_index = performance().now();
         let index = &mut self.drop_items_index; //build_index(&self.drop_items);
-        self.perf_build_index.add(performance().now() - start_index);
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
             let entry = &self.drop_items[i];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,7 @@ pub struct FactorishState {
     perf_build_index: PerfStats,
     perf_drop_items: PerfStats,
     perf_simulate: PerfStats,
+    perf_minimap: PerfStats,
 
     // on_show_inventory: js_sys::Function,
     image_dirt: Option<ImageBundle>,
@@ -561,6 +562,7 @@ impl FactorishState {
             perf_build_index: PerfStats::default(),
             perf_drop_items: PerfStats::default(),
             perf_simulate: PerfStats::default(),
+            perf_minimap: PerfStats::default(),
             image_dirt: None,
             image_back_tiles: None,
             image_weeds: None,
@@ -2852,7 +2854,8 @@ impl FactorishState {
         Ok(())
     }
 
-    pub fn render_minimap(&self, context: CanvasRenderingContext2d) -> Result<(), JsValue> {
+    pub fn render_minimap(&mut self, context: CanvasRenderingContext2d) -> Result<(), JsValue> {
+        let start_render = performance().now();
         let width = self.width as f64;
         let height = self.height as f64;
         context.save();
@@ -2880,6 +2883,7 @@ impl FactorishState {
             viewport.1 / 32.,
         );
         context.restore();
+        self.perf_minimap.add(performance().now() - start_render);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod water_well;
 
 use crate::drop_items::{
     build_index, drop_item_id_iter, drop_item_iter, hit_check, hit_check_with_index, DropItem,
-    DropItemEntry, DropItemId, SplitSlice, DROP_ITEM_SIZE,
+    DropItemEntry, DropItemId, SplitSlice, DROP_ITEM_SIZE, INDEX_CHUNK_SIZE,
 };
 use crate::{
     scenarios::select_scenario,
@@ -1152,7 +1152,7 @@ impl FactorishState {
         }
 
         let index = drop_items::build_index(&self.drop_items);
-        console_log!("Index: {}", index.len());
+        console_log!("Index: {}: {:?}", index.len(), drop_items::hist(&index));
         for i in 0..self.drop_items.len() {
             // (id, item) in drop_item_id_iter_mut(&mut self.drop_items) {
             let entry = &self.drop_items[i];
@@ -2710,6 +2710,17 @@ impl FactorishState {
                     DROP_ITEM_SIZE,
                     DROP_ITEM_SIZE,
                 );
+            }
+            context.set_stroke_style(&js_str!("black"));
+            for y in 0..self.height / INDEX_CHUNK_SIZE {
+                for x in 0..self.width / INDEX_CHUNK_SIZE {
+                    context.stroke_rect(
+                        x as f64 * TILE_SIZE * INDEX_CHUNK_SIZE as f64,
+                        y as f64 * TILE_SIZE * INDEX_CHUNK_SIZE as f64,
+                        TILE_SIZE * INDEX_CHUNK_SIZE as f64,
+                        TILE_SIZE * INDEX_CHUNK_SIZE as f64,
+                    );
+                }
             }
             context.restore();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod inventory;
 mod items;
 mod offshore_pump;
 mod ore_mine;
+mod perf;
 mod perlin_noise;
 mod pipe;
 mod power_network;
@@ -28,11 +29,12 @@ mod transport_belt;
 mod utils;
 mod water_well;
 
-use crate::drop_items::{
-    build_index, drop_item_id_iter, drop_item_iter, hit_check, hit_check_with_index, update_index,
-    DropItem, DropItemEntry, DropItemId, DROP_ITEM_SIZE, INDEX_CHUNK_SIZE,
-};
 use crate::{
+    drop_items::{
+        build_index, drop_item_id_iter, drop_item_iter, hit_check, hit_check_with_index,
+        update_index, DropItem, DropItemEntry, DropItemId, DROP_ITEM_SIZE, INDEX_CHUNK_SIZE,
+    },
+    perf::PerfStats,
     scenarios::select_scenario,
     terrain::{calculate_back_image, TerrainParameters},
 };
@@ -60,11 +62,7 @@ use transport_belt::TransportBelt;
 use water_well::{FluidType, WaterWell};
 
 use serde::{Deserialize, Serialize};
-use std::{
-    cell::RefCell,
-    collections::{HashMap, VecDeque},
-    convert::TryFrom,
-};
+use std::{cell::RefCell, collections::HashMap, convert::TryFrom};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{Clamped, JsCast};
 use web_sys::{
@@ -408,41 +406,6 @@ impl Default for Viewport {
             x: 0.,
             y: 0.,
             scale: 1.,
-        }
-    }
-}
-
-struct PerfStats {
-    values: VecDeque<f64>,
-    total: f64,
-    count: usize,
-}
-
-impl Default for PerfStats {
-    fn default() -> Self {
-        Self {
-            values: VecDeque::new(),
-            total: 0.,
-            count: 0,
-        }
-    }
-}
-
-impl PerfStats {
-    fn add(&mut self, sample: f64) {
-        self.values.push_back(sample);
-        while self.values.len() > 200 {
-            self.values.pop_front();
-        }
-        self.total += sample;
-        self.count += 1;
-    }
-
-    fn average(&self) -> f64 {
-        if self.count == 0 {
-            0.
-        } else {
-            self.total / self.count as f64
         }
     }
 }
@@ -2913,47 +2876,5 @@ impl FactorishState {
         );
         context.restore();
         Ok(())
-    }
-
-    pub fn render_perf(&self, context: CanvasRenderingContext2d) -> js_sys::Array {
-        let canvas = context.canvas().unwrap();
-        let (width, height) = (canvas.width(), canvas.height());
-        context.clear_rect(0., 0., width as f64, height as f64);
-        context.set_line_width(1.);
-
-        let get_max = |vd: &VecDeque<f64>| vd.iter().fold(1.0f64, |a, b| a.max(*b));
-        let get_avg = |vd: &VecDeque<f64>| vd.iter().sum::<f64>() / vd.len() as f64;
-
-        let max = get_max(&self.perf_build_index.values).max(get_max(&self.perf_drop_items.values));
-
-        let plot_series = |vd: &VecDeque<f64>| {
-            let mut series = vd.iter();
-            context.begin_path();
-            series
-                .next()
-                .map(|p| context.move_to(0., (1. - *p / max) * height as f64));
-            for (i, p) in series.enumerate() {
-                context.line_to((i + 1) as f64, (1. - *p / max) * height as f64);
-            }
-            context.stroke();
-        };
-
-        context.set_stroke_style(&JsValue::from_str("blue"));
-        plot_series(&self.perf_build_index.values);
-
-        context.set_stroke_style(&JsValue::from_str("red"));
-        plot_series(&self.perf_drop_items.values);
-
-        js_sys::Array::of3(
-            &js_str!("Max: {:.3} ms", max),
-            &js_str!(
-                "Drop Items Avg: {:.3} ms",
-                get_avg(&self.perf_drop_items.values)
-            ),
-            &js_str!(
-                "Build index Avg: {:.3} ms",
-                get_avg(&self.perf_build_index.values)
-            ),
-        )
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,44 @@
+#[macro_export]
+macro_rules! console_log {
+    ($fmt:expr, $($arg1:expr),*) => {
+        crate::log(&format!($fmt, $($arg1),+))
+    };
+    ($fmt:expr) => {
+        crate::log($fmt)
+    }
+}
+
+/// format-like macro that returns js_sys::String
+#[macro_export]
+macro_rules! js_str {
+    ($fmt:expr, $($arg1:expr),*) => {
+        JsValue::from_str(&format!($fmt, $($arg1),+))
+    };
+    ($fmt:expr) => {
+        JsValue::from_str($fmt)
+    }
+}
+
+/// format-like macro that returns Err(js_sys::String)
+#[macro_export]
+macro_rules! js_err {
+    ($fmt:expr, $($arg1:expr),*) => {
+        Err(JsValue::from_str(&format!($fmt, $($arg1),+)))
+    };
+    ($fmt:expr) => {
+        Err(JsValue::from_str($fmt))
+    }
+}
+
+#[macro_export]
+macro_rules! hash_map {
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+    };
+}

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -242,7 +242,7 @@ impl Structure for OreMine {
                 }
                 let drop_x = output_position.x * TILE_SIZE_I + TILE_SIZE_I / 2;
                 let drop_y = output_position.y * TILE_SIZE_I + TILE_SIZE_I / 2;
-                if !hit_check(drop_item_id_iter(&state.drop_items), drop_x, drop_y, None)
+                if !hit_check(&state.drop_items, drop_x, drop_y, None)
                     && state
                         .tile_at(&output_position)
                         .map(|cell| !cell.water)

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,9 +1,10 @@
 use super::{
     draw_direction_arrow,
+    inventory::{Inventory, InventoryTrait},
     items::ItemType,
     structure::{RotateErr, Structure, StructureDynIter, StructureId},
-    DropItem, FactorishState, FrameProcResult, Inventory, InventoryTrait, Position, Recipe,
-    Rotation, TempEnt, COAL_POWER, TILE_SIZE, TILE_SIZE_I,
+    DropItem, FactorishState, FrameProcResult, Position, Recipe, Rotation, TempEnt, COAL_POWER,
+    TILE_SIZE, TILE_SIZE_I,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,5 +1,6 @@
 use super::{
     draw_direction_arrow,
+    drop_items::{drop_item_id_iter, hit_check},
     inventory::{Inventory, InventoryTrait},
     items::ItemType,
     structure::{RotateErr, Structure, StructureDynIter, StructureId},
@@ -218,7 +219,6 @@ impl Structure for OreMine {
                             if let Ok(val) = output(state, *item.0, &self.position) {
                                 structure
                                     .input(&DropItem {
-                                        id: 0,
                                         type_: *item.0,
                                         x: output_position.x,
                                         y: output_position.y,
@@ -242,7 +242,7 @@ impl Structure for OreMine {
                 }
                 let drop_x = output_position.x * TILE_SIZE_I + TILE_SIZE_I / 2;
                 let drop_y = output_position.y * TILE_SIZE_I + TILE_SIZE_I / 2;
-                if !state.hit_check(drop_x, drop_y, None)
+                if !hit_check(drop_item_id_iter(&state.drop_items), drop_x, drop_y, None)
                     && state
                         .tile_at(&output_position)
                         .map(|cell| !cell.water)

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -1,6 +1,6 @@
 use super::{
     draw_direction_arrow,
-    drop_items::{drop_item_id_iter, hit_check},
+    drop_items::hit_check,
     inventory::{Inventory, InventoryTrait},
     items::ItemType,
     structure::{RotateErr, Structure, StructureDynIter, StructureId},

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -42,7 +42,9 @@ impl FactorishState {
         let get_max = |vd: &VecDeque<f64>| vd.iter().fold(1.0f64, |a, b| a.max(*b));
         let get_avg = |vd: &VecDeque<f64>| vd.iter().sum::<f64>() / vd.len() as f64;
 
-        let max = get_max(&self.perf_build_index.values).max(get_max(&self.perf_drop_items.values));
+        let max = get_max(&self.perf_build_index.values)
+            .max(get_max(&self.perf_drop_items.values))
+            .max(get_max(&self.perf_simulate.values));
 
         let plot_series = |vd: &VecDeque<f64>| {
             let mut series = vd.iter();
@@ -56,13 +58,16 @@ impl FactorishState {
             context.stroke();
         };
 
-        context.set_stroke_style(&JsValue::from_str("blue"));
+        context.set_stroke_style(&JsValue::from_str("#7f7fff"));
         plot_series(&self.perf_build_index.values);
 
-        context.set_stroke_style(&JsValue::from_str("red"));
+        context.set_stroke_style(&JsValue::from_str("#ff3f3f"));
         plot_series(&self.perf_drop_items.values);
 
-        js_sys::Array::of3(
+        context.set_stroke_style(&JsValue::from_str("#00ff00"));
+        plot_series(&self.perf_simulate.values);
+
+        js_sys::Array::of4(
             &js_str!("Max: {:.3} ms", max),
             &js_str!(
                 "Drop Items Avg: {:.3} ms",
@@ -71,6 +76,10 @@ impl FactorishState {
             &js_str!(
                 "Build index Avg: {:.3} ms",
                 get_avg(&self.perf_build_index.values)
+            ),
+            &js_str!(
+                "Simulate Avg: {:.3} ms",
+                get_avg(&self.perf_simulate.values)
             ),
         )
     }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -68,6 +68,9 @@ impl FactorishState {
         context.set_stroke_style(&JsValue::from_str("#007f00"));
         plot_series(&self.perf_simulate.values);
 
+        context.set_stroke_style(&JsValue::from_str("#7f007f"));
+        plot_series(&self.perf_minimap.values);
+
         context.set_stroke_style(&JsValue::from_str("#7f7fff"));
         plot_series(&self.perf_build_index.ma_values);
 
@@ -77,7 +80,10 @@ impl FactorishState {
         context.set_stroke_style(&JsValue::from_str("#00ff00"));
         plot_series(&self.perf_simulate.ma_values);
 
-        js_sys::Array::of4(
+        context.set_stroke_style(&JsValue::from_str("#ff00ff"));
+        plot_series(&self.perf_minimap.ma_values);
+
+        js_sys::Array::of5(
             &js_str!("Max: {:.3} ms", max),
             &js_str!(
                 "Drop Items Avg: {:.3} ms",
@@ -91,6 +97,7 @@ impl FactorishState {
                 "Simulate Avg: {:.3} ms",
                 get_avg(&self.perf_simulate.values)
             ),
+            &js_str!("Minimap Avg: {:.3} ms", get_avg(&self.perf_minimap.values)),
         )
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,0 +1,77 @@
+use std::collections::VecDeque;
+use wasm_bindgen::prelude::*;
+use web_sys::CanvasRenderingContext2d;
+
+use super::FactorishState;
+
+pub(crate) struct PerfStats {
+    values: VecDeque<f64>,
+    total: f64,
+    count: usize,
+}
+
+impl Default for PerfStats {
+    fn default() -> Self {
+        Self {
+            values: VecDeque::new(),
+            total: 0.,
+            count: 0,
+        }
+    }
+}
+
+impl PerfStats {
+    pub(crate) fn add(&mut self, sample: f64) {
+        self.values.push_back(sample);
+        while self.values.len() > 200 {
+            self.values.pop_front();
+        }
+        self.total += sample;
+        self.count += 1;
+    }
+}
+
+#[wasm_bindgen]
+impl FactorishState {
+    pub fn render_perf(&self, context: CanvasRenderingContext2d) -> js_sys::Array {
+        let canvas = context.canvas().unwrap();
+        let (width, height) = (canvas.width(), canvas.height());
+        context.clear_rect(0., 0., width as f64, height as f64);
+        context.set_line_width(1.);
+
+        let get_max = |vd: &VecDeque<f64>| vd.iter().fold(1.0f64, |a, b| a.max(*b));
+        let get_avg = |vd: &VecDeque<f64>| vd.iter().sum::<f64>() / vd.len() as f64;
+
+        let max = get_max(&self.perf_build_index.values).max(get_max(&self.perf_drop_items.values));
+
+        let plot_series = |vd: &VecDeque<f64>| {
+            let mut series = vd.iter();
+            context.begin_path();
+            series
+                .next()
+                .map(|p| context.move_to(0., (1. - *p / max) * height as f64));
+            for (i, p) in series.enumerate() {
+                context.line_to((i + 1) as f64, (1. - *p / max) * height as f64);
+            }
+            context.stroke();
+        };
+
+        context.set_stroke_style(&JsValue::from_str("blue"));
+        plot_series(&self.perf_build_index.values);
+
+        context.set_stroke_style(&JsValue::from_str("red"));
+        plot_series(&self.perf_drop_items.values);
+
+        js_sys::Array::of3(
+            &js_str!("Max: {:.3} ms", max),
+            &js_str!(
+                "Drop Items Avg: {:.3} ms",
+                get_avg(&self.perf_drop_items.values)
+            ),
+            &js_str!(
+                "Build index Avg: {:.3} ms",
+                get_avg(&self.perf_build_index.values)
+            ),
+        )
+    }
+}

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -43,7 +43,7 @@ impl FactorishState {
         let get_max = |vd: &VecDeque<f64>| vd.iter().fold(1.0f64, |a, b| a.max(*b));
         let get_avg = |vd: &VecDeque<f64>| vd.iter().sum::<f64>() / vd.len() as f64;
 
-        let max = get_max(&self.perf_build_index.values)
+        let max = get_max(&self.perf_structures.values)
             .max(get_max(&self.perf_drop_items.values))
             .max(get_max(&self.perf_simulate.values))
             .max(get_max(&self.perf_render.values));
@@ -61,7 +61,7 @@ impl FactorishState {
         };
 
         context.set_stroke_style(&JsValue::from_str("#00007f"));
-        plot_series(&self.perf_build_index.values);
+        plot_series(&self.perf_structures.values);
 
         context.set_stroke_style(&JsValue::from_str("#7f0000"));
         plot_series(&self.perf_drop_items.values);
@@ -76,7 +76,7 @@ impl FactorishState {
         plot_series(&self.perf_render.values);
 
         context.set_stroke_style(&JsValue::from_str("#7f7fff"));
-        plot_series(&self.perf_build_index.ma_values);
+        plot_series(&self.perf_structures.ma_values);
 
         context.set_stroke_style(&JsValue::from_str("#ff3f3f"));
         plot_series(&self.perf_drop_items.ma_values);
@@ -97,8 +97,8 @@ impl FactorishState {
                 get_avg(&self.perf_drop_items.values)
             ),
             &js_str!(
-                "Build index Avg: {:.3} ms",
-                get_avg(&self.perf_build_index.values)
+                "Structures Avg: {:.3} ms",
+                get_avg(&self.perf_structures.values)
             ),
             &js_str!(
                 "Simulate Avg: {:.3} ms",

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -45,7 +45,8 @@ impl FactorishState {
 
         let max = get_max(&self.perf_build_index.values)
             .max(get_max(&self.perf_drop_items.values))
-            .max(get_max(&self.perf_simulate.values));
+            .max(get_max(&self.perf_simulate.values))
+            .max(get_max(&self.perf_render.values));
 
         let plot_series = |vd: &VecDeque<f64>| {
             let mut series = vd.iter();
@@ -71,6 +72,9 @@ impl FactorishState {
         context.set_stroke_style(&JsValue::from_str("#7f007f"));
         plot_series(&self.perf_minimap.values);
 
+        context.set_stroke_style(&JsValue::from_str("#7f7f7f"));
+        plot_series(&self.perf_render.values);
+
         context.set_stroke_style(&JsValue::from_str("#7f7fff"));
         plot_series(&self.perf_build_index.ma_values);
 
@@ -83,7 +87,10 @@ impl FactorishState {
         context.set_stroke_style(&JsValue::from_str("#ff00ff"));
         plot_series(&self.perf_minimap.ma_values);
 
-        js_sys::Array::of5(
+        context.set_stroke_style(&JsValue::from_str("#ffffff"));
+        plot_series(&self.perf_render.ma_values);
+
+        [
             &js_str!("Max: {:.3} ms", max),
             &js_str!(
                 "Drop Items Avg: {:.3} ms",
@@ -98,6 +105,9 @@ impl FactorishState {
                 get_avg(&self.perf_simulate.values)
             ),
             &js_str!("Minimap Avg: {:.3} ms", get_avg(&self.perf_minimap.values)),
-        )
+            &js_str!("Rendering Avg: {:.3} ms", get_avg(&self.perf_render.values)),
+        ]
+        .iter()
+        .collect()
     }
 }

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -2,7 +2,7 @@ use super::{
     assembler::Assembler,
     boiler::Boiler,
     chest::Chest,
-    drop_items::DropItemEntry,
+    drop_items::{build_index, DropItemEntry},
     elect_pole::ElectPole,
     furnace::Furnace,
     inserter::Inserter,
@@ -305,6 +305,8 @@ impl FactorishState {
                 .map(|d| d.on_construction_self(id, &others, true))
                 .unwrap_or(Ok(()))?;
         }
+
+        self.drop_items_index = build_index(&self.drop_items);
 
         Ok(())
     }

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -2,6 +2,7 @@ use super::{
     assembler::Assembler,
     boiler::Boiler,
     chest::Chest,
+    drop_items::DropItemEntry,
     elect_pole::ElectPole,
     furnace::Furnace,
     inserter::Inserter,
@@ -14,7 +15,7 @@ use super::{
     terrain::{calculate_back_image, gen_terrain, TerrainParameters},
     transport_belt::TransportBelt,
     water_well::WaterWell,
-    Cell, DropItem, FactorishState, InventoryTrait, Position, PowerWire, Rotation,
+    Cell, FactorishState, InventoryTrait, Position, PowerWire, Rotation,
 };
 use wasm_bindgen::prelude::*;
 
@@ -45,7 +46,7 @@ fn update_water(
 
 fn default_scenario(
     terrain_params: &TerrainParameters,
-) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>) {
+) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>) {
     (
         vec![
             wrap_structure(Box::new(TransportBelt::new(10, 3, Rotation::Left))),
@@ -65,7 +66,7 @@ fn default_scenario(
 
 fn pipe_bench(
     terrain_params: &TerrainParameters,
-) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>) {
+) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>) {
     let (mut structures, mut terrain, items) = default_scenario(terrain_params);
 
     structures
@@ -84,7 +85,7 @@ fn pipe_bench(
 
 fn inserter_bench(
     terrain_params: &TerrainParameters,
-) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>) {
+) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>) {
     let (mut structures, mut terrain, items) = default_scenario(terrain_params);
 
     structures.extend((10..=100).map(|x| {
@@ -135,26 +136,26 @@ fn inserter_bench(
 
 fn transport_bench(
     terrain_params: &TerrainParameters,
-    serial_no: &mut u32,
-) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>) {
+) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>) {
     let (mut structures, mut terrain, mut items) = default_scenario(terrain_params);
 
     structures.extend(
         (11..=100).map(|x| wrap_structure(Box::new(TransportBelt::new(x, 10, Rotation::Left)))),
     );
-    items.extend((11..=100).map(|x| DropItem::new(serial_no, ItemType::CoalOre, x, 10)));
+    items.extend((11..=100).map(|x| DropItemEntry::new(ItemType::CoalOre, &Position::new(x, 10))));
     structures.extend(
         (10..=99).map(|x| wrap_structure(Box::new(TransportBelt::new(x, 100, Rotation::Right)))),
     );
-    items.extend((10..=99).map(|x| DropItem::new(serial_no, ItemType::IronOre, x, 100)));
+    items.extend((10..=99).map(|x| DropItemEntry::new(ItemType::IronOre, &Position::new(x, 100))));
     structures.extend(
         (10..=99).map(|x| wrap_structure(Box::new(TransportBelt::new(10, x, Rotation::Bottom)))),
     );
-    items.extend((10..=99).map(|x| DropItem::new(serial_no, ItemType::CopperOre, 10, x)));
+    items.extend((10..=99).map(|x| DropItemEntry::new(ItemType::CopperOre, &Position::new(10, x))));
     structures.extend(
         (11..=100).map(|x| wrap_structure(Box::new(TransportBelt::new(100, x, Rotation::Top)))),
     );
-    items.extend((11..=100).map(|x| DropItem::new(serial_no, ItemType::StoneOre, 100, x)));
+    items
+        .extend((11..=100).map(|x| DropItemEntry::new(ItemType::StoneOre, &Position::new(100, x))));
 
     update_water(&structures, &mut terrain, &terrain_params);
 
@@ -163,7 +164,7 @@ fn transport_bench(
 
 fn electric_bench(
     terrain_params: &TerrainParameters,
-) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>) {
+) -> (Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>) {
     let (mut structures, mut terrain, items) = default_scenario(terrain_params);
 
     structures.extend((10..=100).filter_map(|x| {
@@ -205,13 +206,12 @@ fn electric_bench(
 pub(crate) fn select_scenario(
     name: &str,
     terrain_params: &TerrainParameters,
-    serial_no: &mut u32,
-) -> Result<(Vec<StructureEntry>, Vec<Cell>, Vec<DropItem>), JsValue> {
+) -> Result<(Vec<StructureEntry>, Vec<Cell>, Vec<DropItemEntry>), JsValue> {
     match name {
         "default" => Ok(default_scenario(terrain_params)),
         "pipe_bench" => Ok(pipe_bench(terrain_params)),
         "inserter_bench" => Ok(inserter_bench(terrain_params)),
-        "transport_bench" => Ok(transport_bench(terrain_params, serial_no)),
+        "transport_bench" => Ok(transport_bench(terrain_params)),
         "electric_bench" => Ok(electric_bench(terrain_params)),
         _ => js_err!("Scenario name not valid: {}", name),
     }

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -1,8 +1,9 @@
 use super::{
+    drop_items::DropItem,
     structure::{
         BoundingBox, ItemResponse, ItemResponseResult, RotateErr, Size, Structure, StructureDynIter,
     },
-    DropItem, FactorishState, Position, Rotation, TILE_SIZE,
+    FactorishState, Position, Rotation, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1,8 +1,9 @@
 use super::{
+    drop_items::DropItem,
     dyn_iter::{DynIter, DynIterMut},
     items::ItemType,
     water_well::FluidBox,
-    DropItem, FactorishState, Inventory, InventoryTrait, Recipe,
+    FactorishState, Inventory, InventoryTrait, Recipe,
 };
 use rotate_enum::RotateEnum;
 use serde::{Deserialize, Serialize};

--- a/src/transport_belt.rs
+++ b/src/transport_belt.rs
@@ -1,6 +1,7 @@
 use super::{
+    drop_items::DropItem,
     structure::{ItemResponse, ItemResponseResult, Structure, StructureDynIter},
-    DropItem, FactorishState, Position, RotateErr, Rotation, TILE_SIZE,
+    FactorishState, Position, RotateErr, Rotation, TILE_SIZE,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/static/index.html
+++ b/static/index.html
@@ -69,6 +69,7 @@
 						<div><label><input type="checkbox" id="showDebugBBox">Show Debug Bounding Box</label></div>
 						<div><label><input type="checkbox" id="showDebugFluidBox">Show Debug Fluid Box</label></div>
 						<div><label><input type="checkbox" id="showDebugPowerNetwork">Show Debug Power Network</label></div>
+						<div><label><input type="checkbox" id="showPerfGraph">Show performance graph</label></div>
 					</div>
 				</div>
 				<hr>


### PR DESCRIPTION
We implement the discussions in #15 to improve performance especially when there are a lot of items.

Actually, I think the performance bottleneck is Structure lookup for `item_response`, which should be fixed in following PRs.
This PR will improve performance of collision checking between DropItems, which is only the half of the problem.

We also implemented a realtime performance chart on the GUI in order to visualize the performance implications better.

![image](https://user-images.githubusercontent.com/2798715/126882412-1832571d-5312-490b-bd8a-747058907684.png)

Previously, we used `console.log` but it could not show many items in easy to understand manners.