### PR TITLE
Dynamically generate chunks to create illusion of infinite world

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -266,7 +266,10 @@ let unlimited = true;
     };
     miniMapElem.onmousemove = function(evt){
         if(miniMapDrag){
-            sim.delta_viewport_pos((evt.offsetX - miniMapDrag[0]) * tilesize, (evt.offsetY - miniMapDrag[1]) * tilesize);
+            sim.delta_viewport_pos(
+                (evt.offsetX - miniMapDrag[0]) * tilesize,
+                (evt.offsetY - miniMapDrag[1]) * tilesize,
+                false);
             miniMapDrag = [evt.offsetX, evt.offsetY, true];
         }
     };
@@ -1078,7 +1081,7 @@ let unlimited = true;
         if(!paused)
             sim.mouse_move([evt.offsetX, evt.offsetY]);
         if(dragging){
-            sim.delta_viewport_pos(evt.offsetX - dragging[0], evt.offsetY - dragging[1]);
+            sim.delta_viewport_pos(evt.offsetX - dragging[0], evt.offsetY - dragging[1], true);
             dragging = [evt.offsetX, evt.offsetY, true];
         }
     });

--- a/js/main.js
+++ b/js/main.js
@@ -166,7 +166,7 @@ let unlimited = true;
     sliderInit("resourceAmount", "resourceAmountLabel", value => resourceAmount = value);
     let noiseScale = 5.;
     sliderInit("noiseScale", "noiseScaleLabel", value => noiseScale = value);
-    let noiseThreshold = 0.35;
+    let noiseThreshold = 0.30;
     sliderInit("noiseThreshold", "noiseThresholdLabel", value => noiseThreshold = value);
     let noiseOctaves = 3;
     sliderInit("noiseOctaves", "noiseOctavesLabel", value => noiseOctaves = value);

--- a/js/main.js
+++ b/js/main.js
@@ -277,8 +277,8 @@ let unlimited = true;
     miniMapElem.onmouseup = (evt) => miniMapDrag = false;
     miniMapElem.onmouseleave = (evt) => miniMapDrag = false;
     container.appendChild(miniMapElem);
-    miniMapElem.setAttribute("width", xsize);
-    miniMapElem.setAttribute("height", ysize);
+    miniMapElem.setAttribute("width", miniMapSize);
+    miniMapElem.setAttribute("height", miniMapSize);
     miniMapElem.style.width = miniMapSize + 'px';
     miniMapElem.style.height = miniMapSize + 'px';
     miniMapElem.style.right = '8px';
@@ -1276,7 +1276,26 @@ let unlimited = true;
             showBurnerStatus(selPos);
         }
 
-        sim.render_minimap(miniMapContext);
+        const minimapData = sim.render_minimap(miniMapSize, miniMapSize);
+        const viewportScale = sim.get_viewport_scale();
+        if(minimapData){
+            (async () => {
+                const imageBitmap = await createImageBitmap(minimapData);
+                miniMapContext.fillStyle = "#7f7f7f";
+                miniMapContext.fillRect(0, 0, miniMapSize, miniMapSize);
+                miniMapContext.drawImage(imageBitmap, 0, 0, miniMapSize, miniMapSize, 0, 0, miniMapSize, miniMapSize);
+                miniMapContext.strokeStyle = "blue";
+                miniMapContext.lineWidth = 1.;
+                const miniMapRect = miniMapElem.getBoundingClientRect();
+                const viewport = canvas.getBoundingClientRect();
+                miniMapContext.strokeRect(
+                    (miniMapRect.width - viewport.width / 32. / viewportScale) / 2,
+                    (miniMapRect.height - viewport.height / 32. / viewportScale) / 2,
+                    viewport.width / 32. / viewportScale,
+                    viewport.height / 32. / viewportScale,
+                );
+            })()
+        }
 
         if(showPerfGraph.checked){
             const colors = ["#fff", "#ff3f3f", "#7f7fff", "#00ff00", "#ff00ff", "#fff"];

--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,7 @@ function isIE(){
 const tooltipZIndex = 10000;
 let xsize = 128;
 let ysize = 128;
+let unlimited = true;
 
 (async function(){
     // We could fetch and await in Rust code, but it's far easier to do in JavaScript runtime.
@@ -188,6 +189,7 @@ let ysize = 128;
         {
             width: xsize,
             height: ysize,
+            unlimited,
             terrain_seed: terrainSeed,
             water_noise_threshold: waterNoiseThreshold,
             resource_amount: resourceAmount,
@@ -1219,11 +1221,20 @@ let ysize = 128;
 
     const generateBoard = document.getElementById("generateBoard");
     generateBoard.addEventListener("click", () => {
-        xsize = ysize = parseInt(document.getElementById("sizeSelect").value);
+        const sizeStr = document.getElementById("sizeSelect").value;
+        if(sizeStr === "unlimited"){
+            xsize = ysize = 128;
+            unlimited = true;
+        }
+        else{
+            xsize = ysize = parseInt(sizeStr);
+            unlimited = false;
+        }
         sim = new FactorishState(
             {
                 width: xsize,
                 height: ysize,
+                unlimited,
                 terrain_seed: terrainSeed,
                 water_noise_threshold: waterNoiseThreshold,
                 resource_amount: resourceAmount,

--- a/js/main.js
+++ b/js/main.js
@@ -160,14 +160,16 @@ let unlimited = true;
         });
     }
 
-    let waterNoiseThreshold = 0.35;
+    let waterNoiseThreshold = 0.28;
     sliderInit("waterNoiseThreshold", "waterNoiseThresholdLabel", value => waterNoiseThreshold = value);
     let resourceAmount = 1000.;
     sliderInit("resourceAmount", "resourceAmountLabel", value => resourceAmount = value);
     let noiseScale = 5.;
     sliderInit("noiseScale", "noiseScaleLabel", value => noiseScale = value);
-    let noiseThreshold = 0.45;
+    let noiseThreshold = 0.35;
     sliderInit("noiseThreshold", "noiseThresholdLabel", value => noiseThreshold = value);
+    let noiseOctaves = 3;
+    sliderInit("noiseOctaves", "noiseOctavesLabel", value => noiseOctaves = value);
 
     function initPane(buttonId, containerId){
         const button = document.getElementById(buttonId);
@@ -195,6 +197,7 @@ let unlimited = true;
             resource_amount: resourceAmount,
             noise_scale: noiseScale,
             noise_threshold: noiseThreshold,
+            noise_octaves: noiseOctaves,
         },
         updateInventory,
         scenarioSelectElem.value);
@@ -1239,6 +1242,7 @@ let unlimited = true;
                 resource_amount: resourceAmount,
                 noise_scale: noiseScale,
                 noise_threshold: noiseThreshold,
+                noise_octaves: noiseOctaves,
             },
             updateInventory,
             scenarioSelectElem.value);

--- a/js/main.js
+++ b/js/main.js
@@ -201,8 +201,6 @@ let unlimited = true;
 
     const canvas = document.getElementById('canvas');
     let canvasSize = canvas.getBoundingClientRect();
-    let viewPortWidth = canvasSize.width / 32;
-    let viewPortHeight = canvasSize.height / 32;
     const refreshSize = (event) => {
         canvasSize = canvas.getBoundingClientRect();
         canvas.width = canvasSize.width;
@@ -253,7 +251,7 @@ let unlimited = true;
     let selectedInventory = null;
     let selectedInventoryItem = null;
 
-    let miniMapDrag = false;
+    let miniMapDrag = null;
     const tilesize = 32;
     const textType = isIE() ? "Text" : "text/plain";
     var windowZIndex = 1000;
@@ -264,14 +262,12 @@ let unlimited = true;
     miniMapElem.style.position = 'absolute';
     miniMapElem.style.border = '1px solid #000';
     miniMapElem.onmousedown = (evt) => {
-        miniMapDrag = true;
+        miniMapDrag = [evt.offsetX, evt.offsetY];
     };
     miniMapElem.onmousemove = function(evt){
         if(miniMapDrag){
-            var rect = this.getBoundingClientRect();
-            const viewport = sim.set_viewport_pos((evt.clientX - rect.left) / rect.width * xsize,
-                (evt.clientY - rect.top) / rect.height * ysize);
-            [viewPortWidth, viewPortHeight] = [viewport[0] / 32., viewport[1] / 32.];
+            sim.delta_viewport_pos((evt.offsetX - miniMapDrag[0]) * tilesize, (evt.offsetY - miniMapDrag[1]) * tilesize);
+            miniMapDrag = [evt.offsetX, evt.offsetY, true];
         }
     };
     miniMapElem.onmouseup = (evt) => miniMapDrag = false;

--- a/src/drop_items.rs
+++ b/src/drop_items.rs
@@ -111,9 +111,12 @@ pub(crate) fn build_index(items: &[DropItemEntry]) -> DropItemIndex {
         .enumerate()
         .filter_map(|(i, item)| Some((GenId::new(i as u32, item.gen), item.item.as_ref()?)))
     {
-        ret.entry((item.x / INDEX_GRID_SIZE_I, item.y / INDEX_GRID_SIZE_I))
-            .or_default()
-            .push(id);
+        ret.entry((
+            item.x.div_euclid(INDEX_GRID_SIZE_I),
+            item.y.div_euclid(INDEX_GRID_SIZE_I),
+        ))
+        .or_default()
+        .push(id);
     }
     ret
 }
@@ -142,7 +145,10 @@ pub(crate) fn hit_check(
 }
 
 pub(crate) fn add_index(index: &mut DropItemIndex, id: GenId, x: i32, y: i32) {
-    let new_chunk = (x / INDEX_GRID_SIZE_I, y / INDEX_GRID_SIZE_I);
+    let new_chunk = (
+        x.div_euclid(INDEX_GRID_SIZE_I),
+        y.div_euclid(INDEX_GRID_SIZE_I),
+    );
     index.entry(new_chunk).or_default().push(id);
 }
 
@@ -154,8 +160,14 @@ pub(crate) fn update_index(
     x: i32,
     y: i32,
 ) {
-    let old_chunk = (old_x / INDEX_GRID_SIZE_I, old_y / INDEX_GRID_SIZE_I);
-    let new_chunk = (x / INDEX_GRID_SIZE_I, y / INDEX_GRID_SIZE_I);
+    let old_chunk = (
+        old_x.div_euclid(INDEX_GRID_SIZE_I),
+        old_y.div_euclid(INDEX_GRID_SIZE_I),
+    );
+    let new_chunk = (
+        x.div_euclid(INDEX_GRID_SIZE_I),
+        y.div_euclid(INDEX_GRID_SIZE_I),
+    );
     if old_chunk == new_chunk {
         return;
     }
@@ -164,7 +176,10 @@ pub(crate) fn update_index(
 }
 
 pub(crate) fn remove_index(index: &mut DropItemIndex, id: GenId, old_x: i32, old_y: i32) {
-    let old_chunk = (old_x / INDEX_GRID_SIZE_I, old_y / INDEX_GRID_SIZE_I);
+    let old_chunk = (
+        old_x.div_euclid(INDEX_GRID_SIZE_I),
+        old_y.div_euclid(INDEX_GRID_SIZE_I),
+    );
     if let Some(chunk) = index.get_mut(&old_chunk) {
         if let Some((remove_idx, _)) = chunk.iter().enumerate().find(|(_, item)| **item == id) {
             chunk.swap_remove(remove_idx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1414,13 +1414,14 @@ impl FactorishState {
     //         .map(|s| s.as_mut())
     // }
 
-    fn _find_structure(&self, pos: &[f64]) -> Option<&dyn Structure> {
-        self.find_structure_tile(&[(pos[0] / 32.) as i32, (pos[1] / 32.) as i32])
-    }
+    // fn _find_structure(&self, pos: &[f64]) -> Option<&dyn Structure> {
+    //     self.find_structure_tile(&[(pos[0] / 32.) as i32, (pos[1] / 32.) as i32])
+    // }
 
     fn find_item(&self, pos: &Position) -> Option<(DropItemId, &DropItem)> {
-        drop_item_id_iter(&self.drop_items)
-            .find(|(_, item)| item.x / 32 == pos.x && item.y / 32 == pos.y)
+        drop_item_id_iter(&self.drop_items).find(|(_, item)| {
+            item.x.div_euclid(TILE_SIZE_I) == pos.x && item.y.div_euclid(TILE_SIZE_I) == pos.y
+        })
     }
 
     fn remove_item(&mut self, id: DropItemId) -> Option<DropItem> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2708,9 +2708,23 @@ impl FactorishState {
         ))
     }
 
-    pub fn delta_viewport_pos(&mut self, x: f64, y: f64) -> Result<(), JsValue> {
-        self.viewport.x += x / self.viewport.scale / 32.;
-        self.viewport.y += y / self.viewport.scale / 32.;
+    /// Move viewport relative to current position. Intended for use with mouse move.
+    ///
+    /// * `scale_relative` -  If true, the delta is divided by current view zoom factor.
+    ///   Intended for use with the minimap, which does not change scale.
+    pub fn delta_viewport_pos(
+        &mut self,
+        x: f64,
+        y: f64,
+        scale_relative: bool,
+    ) -> Result<(), JsValue> {
+        if scale_relative {
+            self.viewport.x += x / self.viewport.scale / TILE_SIZE;
+            self.viewport.y += y / self.viewport.scale / TILE_SIZE;
+        } else {
+            self.viewport.x += x / TILE_SIZE;
+            self.viewport.y += y / TILE_SIZE;
+        }
 
         self.gen_chunks_in_viewport();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     perf::PerfStats,
     scenarios::select_scenario,
-    terrain::{calculate_back_image, Chunks, TerrainParameters, CHUNK_SIZE, CHUNK_SIZE2},
+    terrain::{calculate_back_image_all, Chunks, TerrainParameters, CHUNK_SIZE, CHUNK_SIZE2},
 };
 use assembler::Assembler;
 use boiler::Boiler;
@@ -851,9 +851,9 @@ impl FactorishState {
                 let y: usize = json_as_u64(json_get(&position, 1)?)? as usize;
                 new_chunk[x + y * CHUNK_SIZE] = from_value(json_take(tile, "cell")?)?;
             }
-            calculate_back_image(&mut new_chunk);
             self.board.insert(chunk_pos, new_chunk);
         }
+        calculate_back_image_all(&mut self.board);
 
         let structures = json
             .get_mut("structures")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2795,6 +2795,7 @@ impl FactorishState {
 
         const WIRE_ATTACH_X: f64 = 28.;
         const WIRE_ATTACH_Y: f64 = 8.;
+        const WIRE_HANG: f64 = 0.15;
 
         let draw_wires = |wires: &[PowerWire]| {
             for PowerWire(first, second) in wires {
@@ -2813,9 +2814,13 @@ impl FactorishState {
                 } else {
                     continue;
                 };
+                let dx = (first.x - second.x) as f64;
+                let dy = (first.y - second.y) as f64;
+                let dist = (dx * dx + dy * dy).sqrt();
                 context.quadratic_curve_to(
                     (first.x + second.x) as f64 / 2. * TILE_SIZE + WIRE_ATTACH_X,
-                    (first.y + second.y) as f64 / 1.9 * TILE_SIZE + WIRE_ATTACH_Y,
+                    ((first.y + second.y) as f64 / 2. + dist * WIRE_HANG) * TILE_SIZE
+                        + WIRE_ATTACH_Y,
                     second.x as f64 * TILE_SIZE + WIRE_ATTACH_X,
                     second.y as f64 * TILE_SIZE + WIRE_ATTACH_Y,
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod furnace;
 mod inserter;
 mod inventory;
 mod items;
+mod minimap;
 mod offshore_pump;
 mod ore_mine;
 mod perf;
@@ -69,10 +70,8 @@ use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 use std::{collections::HashMap, convert::TryFrom};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::{Clamped, JsCast};
-use web_sys::{
-    CanvasRenderingContext2d, HtmlCanvasElement, HtmlDivElement, ImageBitmap, ImageData,
-};
+use wasm_bindgen::JsCast;
+use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlDivElement, ImageBitmap};
 
 #[wasm_bindgen]
 extern "C" {
@@ -2353,81 +2352,6 @@ impl FactorishState {
         }
     }
 
-    fn render_minimap_data(&mut self) -> Result<(), JsValue> {
-        let mut chunks = std::mem::take(&mut self.board);
-        let mut painted = 0;
-        for (chunk_pos, chunk) in &mut chunks {
-            painted += self.render_minimap_chunk(chunk_pos, chunk);
-        }
-        self.board = chunks;
-
-        console_log!("painted {}", painted);
-
-        Ok(())
-    }
-
-    fn render_minimap_chunk(&self, chunk_pos: &Position, chunk: &mut Chunk) -> usize {
-        let mut painted = 0;
-        let data = &mut chunk.minimap_buffer;
-
-        for y in 0..CHUNK_SIZE_I {
-            for x in 0..CHUNK_SIZE_I {
-                let cell_pos = Position::new(x, y);
-                if let Some(cell) = chunk.cells.get((x + y * CHUNK_SIZE_I) as usize) {
-                    let start = ((cell_pos.x + cell_pos.y * CHUNK_SIZE_I) * 4) as usize;
-                    data[start + 3] = 255;
-                    let color = Self::color_of_cell(&cell);
-                    data[start..start + 3].copy_from_slice(&color);
-                    painted += 1;
-                }
-            }
-        }
-
-        // context.set_fill_style(&JsValue::from_str("#00ff7f"));
-        let color = [0x00, 0xff, 0x7f];
-        for structure in self.structure_iter() {
-            let Position { x, y } = *structure.position();
-            if chunk_pos.x * CHUNK_SIZE_I <= x
-                && x < (chunk_pos.x + 1) * CHUNK_SIZE_I
-                && chunk_pos.y * CHUNK_SIZE_I <= y
-                && y < (chunk_pos.y + 1) * CHUNK_SIZE_I
-            {
-                let start = ((x.rem_euclid(CHUNK_SIZE_I)
-                    + y.rem_euclid(CHUNK_SIZE_I) * CHUNK_SIZE_I)
-                    * 4) as usize;
-                data[start..start + 3].copy_from_slice(&color);
-            }
-        }
-
-        painted
-    }
-
-    fn render_minimap_data_pixel(&self, chunks: &mut Chunks, position: &Position) {
-        let color = self
-            .structures
-            .iter()
-            .find(|structure| {
-                structure
-                    .dynamic
-                    .as_deref()
-                    .map(|s| *s.position() == *position)
-                    .unwrap_or(false)
-            })
-            .map(|_| [0x00, 0xff, 0x7f])
-            .or_else(|| {
-                self.tile_at(position)
-                    .map(|cell| Self::color_of_cell(&cell))
-            })
-            .unwrap_or([0x7f, 0x7f, 0x7f]);
-        let (chunk_pos, cell_pos) = position.div_mod(CHUNK_SIZE_I);
-        if let Some(chunk) = chunks.get_mut(&chunk_pos) {
-            let start = ((cell_pos.x + cell_pos.y * CHUNK_SIZE_I) * 4) as usize;
-            if start + 3 < chunk.minimap_buffer.len() {
-                chunk.minimap_buffer[start..start + 3].copy_from_slice(&color);
-            }
-        }
-    }
-
     pub fn reset_viewport(&mut self, canvas: HtmlCanvasElement) {
         self.viewport_width = canvas.width() as f64;
         self.viewport_height = canvas.height() as f64;
@@ -3054,93 +2978,5 @@ impl FactorishState {
 
         self.perf_render.add(performance().now() - start_render);
         Ok(())
-    }
-
-    /// Instead of rendering the minimap on the canvas context, it will return a ImageData
-    /// that can be used to construct ImageBitmap on JS side, because dealing with promise in Rust
-    /// code is cumbersome.
-    pub fn render_minimap(
-        &mut self,
-        minimap_width: u32,
-        minimap_height: u32,
-    ) -> Result<ImageData, JsValue> {
-        let start_render = performance().now();
-
-        struct ImageBuffer<'a> {
-            buf: &'a mut [u8],
-            width: usize,
-            height: usize,
-        }
-
-        fn copy_rect(dest: &mut ImageBuffer, src: &ImageBuffer, x: i32, y: i32) {
-            let x0 = x.min(dest.width as i32).max(0) as usize;
-            let x1 = (x + src.width as i32).min(dest.width as i32).max(0) as usize;
-            let sx0 = (x0 as i32 - x).min(src.width as i32).max(0) as usize;
-            if x0 == x1 {
-                return;
-            }
-            let sx1 = (sx0 + (x1 - x0)).min(src.width).max(0) as usize;
-            let y0 = y.min(dest.height as i32).max(0);
-            let sy0 = (y0 - y) as usize;
-            let y0 = y0 as usize;
-            let y1 = (y + src.height as i32).min(dest.height as i32).max(0) as usize;
-            if y0 == y1 {
-                return;
-            }
-            // let dblen = dest.buf.len();
-            // let sblen = src.buf.len();
-            // console_log!("src: {} y: {} y1: {} sx0 {}, sx1 {}", src.height, y, y1, sx0, sx1);
-            for y in y0..y1 {
-                let sy = y - y0 + sy0;
-                let d0 = (x0 + y * dest.width) * 4;
-                let d1 = (x1 + y * dest.width) * 4;
-                let s0 = (sx0 + sy * src.width) * 4;
-                let s1 = (sx1 + sy * src.width) * 4;
-                // console_log!("y {}: d [{}] {}..{}/{} s [{}] {}..{}/{}", y,
-                //     d1 - d0, d0, d1, dblen,
-                //     s1 - s0, s0, s1, sblen);
-                let d = &mut dest.buf[d0..d1];
-                let s = &src.buf[s0..s1];
-                if d.len() != s.len() {
-                    panic!("d {} s {}", d.len(), s.len());
-                }
-                d.copy_from_slice(s);
-            }
-        }
-
-        let vp = self.get_viewport();
-        let data = &mut self.minimap_buffer;
-        if data.len() != (minimap_width * minimap_height * 4) as usize {
-            *data = vec![0u8; (minimap_width * minimap_height * 4) as usize];
-        }
-
-        data.fill(0);
-        let mut data_buf = ImageBuffer {
-            buf: data.as_mut(),
-            width: minimap_width as usize,
-            height: minimap_height as usize,
-        };
-        for (pos, chunk) in &mut self.board {
-            let src = ImageBuffer {
-                buf: &mut chunk.minimap_buffer,
-                width: CHUNK_SIZE,
-                height: CHUNK_SIZE,
-            };
-            copy_rect(
-                &mut data_buf,
-                &src,
-                pos.x * CHUNK_SIZE_I + self.viewport.x as i32 + minimap_width as i32 / 2
-                    - (vp.0 / CHUNK_SIZE_F) as i32 / 4,
-                pos.y * CHUNK_SIZE_I + self.viewport.y as i32 + minimap_height as i32 / 2
-                    - (vp.1 / CHUNK_SIZE_F) as i32 / 4,
-            );
-        }
-        let image_data = ImageData::new_with_u8_clamped_array_and_sh(
-            Clamped::<_>(&mut *data),
-            minimap_width as u32,
-            minimap_height as u32,
-        )?;
-        self.perf_minimap.add(performance().now() - start_render);
-        return Ok(image_data);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use crate::{
     scenarios::select_scenario,
     terrain::{
         calculate_back_image, calculate_back_image_all, gen_chunk, Chunk, Chunks,
-        TerrainParameters, CHUNK_SIZE, CHUNK_SIZE2, CHUNK_SIZE_F, CHUNK_SIZE_I,
+        TerrainParameters, CHUNK_SIZE, CHUNK_SIZE2, CHUNK_SIZE_I,
     },
 };
 use assembler::Assembler;

--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -1,0 +1,175 @@
+use super::{
+    performance,
+    structure::Position,
+    terrain::{Chunk, Chunks, CHUNK_SIZE, CHUNK_SIZE_F, CHUNK_SIZE_I},
+    FactorishState,
+};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::Clamped;
+use web_sys::ImageData;
+
+struct ImageBuffer<'a> {
+    buf: &'a mut [u8],
+    width: usize,
+    height: usize,
+}
+
+fn copy_rect(dest: &mut ImageBuffer, src: &ImageBuffer, x: i32, y: i32) {
+    let x0 = x.min(dest.width as i32).max(0) as usize;
+    let x1 = (x + src.width as i32).min(dest.width as i32).max(0) as usize;
+    let sx0 = (x0 as i32 - x).min(src.width as i32).max(0) as usize;
+    if x0 == x1 {
+        return;
+    }
+    let sx1 = (sx0 + (x1 - x0)).min(src.width).max(0) as usize;
+    let y0 = y.min(dest.height as i32).max(0);
+    let sy0 = (y0 - y) as usize;
+    let y0 = y0 as usize;
+    let y1 = (y + src.height as i32).min(dest.height as i32).max(0) as usize;
+    if y0 == y1 {
+        return;
+    }
+    // let dblen = dest.buf.len();
+    // let sblen = src.buf.len();
+    // console_log!("src: {} y: {} y1: {} sx0 {}, sx1 {}", src.height, y, y1, sx0, sx1);
+    for y in y0..y1 {
+        let sy = y - y0 + sy0;
+        let d0 = (x0 + y * dest.width) * 4;
+        let d1 = (x1 + y * dest.width) * 4;
+        let s0 = (sx0 + sy * src.width) * 4;
+        let s1 = (sx1 + sy * src.width) * 4;
+        // console_log!("y {}: d [{}] {}..{}/{} s [{}] {}..{}/{}", y,
+        //     d1 - d0, d0, d1, dblen,
+        //     s1 - s0, s0, s1, sblen);
+        let d = &mut dest.buf[d0..d1];
+        let s = &src.buf[s0..s1];
+        if d.len() != s.len() {
+            panic!("d {} s {}", d.len(), s.len());
+        }
+        d.copy_from_slice(s);
+    }
+}
+
+#[wasm_bindgen]
+impl FactorishState {
+    pub(crate) fn render_minimap_data(&mut self) -> Result<(), JsValue> {
+        let mut chunks = std::mem::take(&mut self.board);
+        let mut painted = 0;
+        for (chunk_pos, chunk) in &mut chunks {
+            painted += self.render_minimap_chunk(chunk_pos, chunk);
+        }
+        self.board = chunks;
+
+        console_log!("painted {}", painted);
+
+        Ok(())
+    }
+
+    pub(crate) fn render_minimap_chunk(&self, chunk_pos: &Position, chunk: &mut Chunk) -> usize {
+        let mut painted = 0;
+        let data = &mut chunk.minimap_buffer;
+
+        for y in 0..CHUNK_SIZE_I {
+            for x in 0..CHUNK_SIZE_I {
+                let cell_pos = Position::new(x, y);
+                if let Some(cell) = chunk.cells.get((x + y * CHUNK_SIZE_I) as usize) {
+                    let start = ((cell_pos.x + cell_pos.y * CHUNK_SIZE_I) * 4) as usize;
+                    data[start + 3] = 255;
+                    let color = Self::color_of_cell(&cell);
+                    data[start..start + 3].copy_from_slice(&color);
+                    painted += 1;
+                }
+            }
+        }
+
+        // context.set_fill_style(&JsValue::from_str("#00ff7f"));
+        let color = [0x00, 0xff, 0x7f];
+        for structure in self.structure_iter() {
+            let Position { x, y } = *structure.position();
+            if chunk_pos.x * CHUNK_SIZE_I <= x
+                && x < (chunk_pos.x + 1) * CHUNK_SIZE_I
+                && chunk_pos.y * CHUNK_SIZE_I <= y
+                && y < (chunk_pos.y + 1) * CHUNK_SIZE_I
+            {
+                let start = ((x.rem_euclid(CHUNK_SIZE_I)
+                    + y.rem_euclid(CHUNK_SIZE_I) * CHUNK_SIZE_I)
+                    * 4) as usize;
+                data[start..start + 3].copy_from_slice(&color);
+            }
+        }
+
+        painted
+    }
+
+    pub(crate) fn render_minimap_data_pixel(&self, chunks: &mut Chunks, position: &Position) {
+        let color = self
+            .structures
+            .iter()
+            .find(|structure| {
+                structure
+                    .dynamic
+                    .as_deref()
+                    .map(|s| *s.position() == *position)
+                    .unwrap_or(false)
+            })
+            .map(|_| [0x00, 0xff, 0x7f])
+            .or_else(|| {
+                self.tile_at(position)
+                    .map(|cell| Self::color_of_cell(&cell))
+            })
+            .unwrap_or([0x7f, 0x7f, 0x7f]);
+        let (chunk_pos, cell_pos) = position.div_mod(CHUNK_SIZE_I);
+        if let Some(chunk) = chunks.get_mut(&chunk_pos) {
+            let start = ((cell_pos.x + cell_pos.y * CHUNK_SIZE_I) * 4) as usize;
+            if start + 3 < chunk.minimap_buffer.len() {
+                chunk.minimap_buffer[start..start + 3].copy_from_slice(&color);
+            }
+        }
+    }
+
+    /// Instead of rendering the minimap on the canvas context, it will return a ImageData
+    /// that can be used to construct ImageBitmap on JS side, because dealing with promise in Rust
+    /// code is cumbersome.
+    pub fn render_minimap(
+        &mut self,
+        minimap_width: u32,
+        minimap_height: u32,
+    ) -> Result<ImageData, JsValue> {
+        let start_render = performance().now();
+
+        let vp = self.get_viewport();
+        let data = &mut self.minimap_buffer;
+        if data.len() != (minimap_width * minimap_height * 4) as usize {
+            *data = vec![0u8; (minimap_width * minimap_height * 4) as usize];
+        }
+
+        data.fill(0);
+        let mut data_buf = ImageBuffer {
+            buf: data.as_mut(),
+            width: minimap_width as usize,
+            height: minimap_height as usize,
+        };
+        for (pos, chunk) in &mut self.board {
+            let src = ImageBuffer {
+                buf: &mut chunk.minimap_buffer,
+                width: CHUNK_SIZE,
+                height: CHUNK_SIZE,
+            };
+            copy_rect(
+                &mut data_buf,
+                &src,
+                pos.x * CHUNK_SIZE_I + self.viewport.x as i32 + minimap_width as i32 / 2
+                    - (vp.0 / CHUNK_SIZE_F) as i32 / 4,
+                pos.y * CHUNK_SIZE_I + self.viewport.y as i32 + minimap_height as i32 / 2
+                    - (vp.1 / CHUNK_SIZE_F) as i32 / 4,
+            );
+        }
+        let image_data = ImageData::new_with_u8_clamped_array_and_sh(
+            Clamped::<_>(&mut *data),
+            minimap_width as u32,
+            minimap_height as u32,
+        )?;
+        self.perf_minimap.add(performance().now() - start_render);
+        return Ok(image_data);
+    }
+}

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -117,8 +117,11 @@ impl Structure for OreMine {
     }
 
     fn desc(&self, state: &FactorishState) -> String {
-        let tile = &state.board
-            [self.position.x as usize + self.position.y as usize * state.width as usize];
+        let tile = if let Some(tile) = state.tile_at(&self.position) {
+            tile
+        } else {
+            return "Cell not found".to_string();
+        };
         if let Some(_recipe) = &self.recipe {
             // Progress bar
             format!("{}{}{}{}{}",

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -60,21 +60,22 @@ fn update_water(
 fn default_scenario(
     terrain_params: &TerrainParameters,
 ) -> (Vec<StructureEntry>, Chunks, Vec<DropItemEntry>) {
-    (
-        vec![
-            wrap_structure(Box::new(TransportBelt::new(10, 3, Rotation::Left))),
-            wrap_structure(Box::new(TransportBelt::new(11, 3, Rotation::Left))),
-            wrap_structure(Box::new(TransportBelt::new(12, 3, Rotation::Left))),
-            wrap_structure(Box::new(OreMine::new(12, 2, Rotation::Bottom))),
-            wrap_structure(Box::new(Furnace::new(&Position::new(8, 3)))),
-            wrap_structure(Box::new(Assembler::new(&Position::new(6, 3)))),
-            wrap_structure(Box::new(WaterWell::new(&Position::new(14, 5)))),
-            wrap_structure(Box::new(Boiler::new(&Position::new(13, 5)))),
-            wrap_structure(Box::new(SteamEngine::new(&Position::new(12, 5)))),
-        ],
-        gen_terrain(terrain_params),
-        vec![],
-    )
+    let structures = vec![
+        wrap_structure(Box::new(TransportBelt::new(10, 3, Rotation::Left))),
+        wrap_structure(Box::new(TransportBelt::new(11, 3, Rotation::Left))),
+        wrap_structure(Box::new(TransportBelt::new(12, 3, Rotation::Left))),
+        wrap_structure(Box::new(OreMine::new(12, 2, Rotation::Bottom))),
+        wrap_structure(Box::new(Furnace::new(&Position::new(8, 3)))),
+        wrap_structure(Box::new(Assembler::new(&Position::new(6, 3)))),
+        wrap_structure(Box::new(Boiler::new(&Position::new(13, 5)))),
+        wrap_structure(Box::new(Pipe::new(&Position::new(12, 5)))),
+        wrap_structure(Box::new(SteamEngine::new(&Position::new(11, 5)))),
+    ];
+    let mut terrain = gen_terrain(terrain_params);
+
+    update_water(&structures, &mut terrain, &terrain_params);
+
+    (structures, terrain, vec![])
 }
 
 fn pipe_bench(

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -51,9 +51,9 @@ fn update_water(
 
     // Update back image in only touched chunks
     for chunk_pos in &to_update {
-        let mut chunk = std::mem::take(terrain.get_mut(chunk_pos).unwrap());
-        calculate_back_image(terrain, &chunk_pos, &mut chunk);
-        terrain.insert(*chunk_pos, chunk);
+        let mut cells = std::mem::take(&mut terrain.get_mut(chunk_pos).unwrap().cells);
+        calculate_back_image(terrain, &chunk_pos, &mut cells);
+        terrain.get_mut(chunk_pos).map(|c| c.cells = cells);
     }
 }
 

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -16,7 +16,6 @@ use super::{
         calculate_back_image, gen_terrain, Chunks, ChunksExt, TerrainParameters, CHUNK_SIZE_I,
     },
     transport_belt::TransportBelt,
-    water_well::WaterWell,
     FactorishState, InventoryTrait, Position, PowerWire, Rotation,
 };
 use std::collections::HashSet;

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -227,6 +227,13 @@ impl Position {
     pub fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
+
+    pub(crate) fn div_mod(&self, size: i32) -> (Position, Position) {
+        let div = Position::new(self.x / size, self.y / size);
+        let mod_ = Position::new(self.x % size, self.y % size);
+        (div, mod_)
+    }
+
     pub(crate) fn add(&self, o: (i32, i32)) -> Position {
         Self {
             x: self.x + o.0,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -230,8 +230,8 @@ impl Position {
     }
 
     pub(crate) fn div_mod(&self, size: i32) -> (Position, Position) {
-        let div = Position::new(self.x / size, self.y / size);
-        let mod_ = Position::new(self.x % size, self.y % size);
+        let div = Position::new(self.x.div_euclid(size), self.y.div_euclid(size));
+        let mod_ = Position::new(self.x.rem_euclid(size), self.y.rem_euclid(size));
         (div, mod_)
     }
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::prelude::*;
 pub(crate) struct TerrainParameters {
     pub width: u32,
     pub height: u32,
+    pub unlimited: bool,
     pub terrain_seed: u32,
     pub water_noise_threshold: f64,
     pub resource_amount: f64,

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -205,8 +205,8 @@ pub(crate) fn calculate_back_image(terrain: &Chunks, chunk_pos: &Position, ret: 
             };
 
             cell.grass_image = ((perlin_noise_pixel(
-                x as f64 / noise_scale,
-                y as f64 / noise_scale,
+                (x + chunk_pos.x * CHUNK_SIZE_I) as f64 / noise_scale,
+                (y + chunk_pos.y * CHUNK_SIZE_I) as f64 / noise_scale,
                 bits,
                 &grass_terms,
             ) - 0.)

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -65,7 +65,7 @@ impl ChunksExt for Chunks {
 /// Generate a chunk at given position. It does not update background image, because it requires
 /// knowledge on connecting chunks. The caller needs to call [`calculate_back_image`] or
 /// [`calculate_back_image_all`] at some point.
-fn gen_chunk(position: Position, terrain_params: &TerrainParameters) -> Chunk {
+pub(crate) fn gen_chunk(position: Position, terrain_params: &TerrainParameters) -> Chunk {
     let TerrainParameters {
         terrain_seed,
         water_noise_threshold,

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -62,14 +62,16 @@ impl ChunksExt for Chunks {
     }
 }
 
-fn gen_chunk(
-    position: Position,
-    terrain_seed: u32,
-    noise_threshold: f64,
-    water_noise_threshold: f64,
-    resource_amount: f64,
-) -> Chunk {
-    let noise_scale = 3.75213;
+fn gen_chunk(position: Position, terrain_params: &TerrainParameters) -> Chunk {
+    let TerrainParameters {
+        terrain_seed,
+        water_noise_threshold,
+        resource_amount,
+        noise_scale,
+        noise_threshold,
+        ..
+    } = *terrain_params;
+
     let mut ret = vec![Cell::default(); CHUNK_SIZE2];
     let bits = 1;
     let mut rng = Xor128::new(terrain_seed);
@@ -122,30 +124,13 @@ fn gen_chunk(
 }
 
 pub(crate) fn gen_terrain(params: &TerrainParameters) -> Chunks {
-    let TerrainParameters {
-        width,
-        height,
-        terrain_seed,
-        water_noise_threshold,
-        resource_amount,
-        noise_scale: _,
-        noise_threshold,
-    } = *params;
+    let TerrainParameters { width, height, .. } = *params;
 
     let mut ret = HashMap::new();
     for y in 0..height as usize / CHUNK_SIZE {
         for x in 0..width as usize / CHUNK_SIZE {
             let pos = Position::new(x as i32, y as i32);
-            ret.insert(
-                pos,
-                gen_chunk(
-                    pos,
-                    terrain_seed,
-                    noise_threshold,
-                    water_noise_threshold,
-                    resource_amount,
-                ),
-            );
+            ret.insert(pos, gen_chunk(pos, params));
         }
     }
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -17,6 +17,7 @@ pub(crate) struct TerrainParameters {
     pub resource_amount: f64,
     pub noise_scale: f64,
     pub noise_threshold: f64,
+    pub noise_octaves: u32,
 }
 
 pub(crate) const CHUNK_SIZE: usize = 16;
@@ -88,11 +89,12 @@ pub(crate) fn gen_chunk(position: Position, terrain_params: &TerrainParameters) 
         resource_amount,
         noise_scale,
         noise_threshold,
+        noise_octaves,
         ..
     } = *terrain_params;
 
     let mut ret = vec![Cell::default(); CHUNK_SIZE2];
-    let bits = 1;
+    let bits = noise_octaves;
     let mut rng = Xor128::new(terrain_seed);
     let ocean_terms = gen_terms(&mut rng, bits);
     let iron_terms = gen_terms(&mut rng, bits);

--- a/static/index.html
+++ b/static/index.html
@@ -47,7 +47,7 @@
 						</div>
 						<div>
 							Water Noise Threshold=<span id="waterNoiseThresholdLabel"></span>
-							<input id="waterNoiseThreshold" type="range" max="1" min="0" step="1e-3" value="0.35">
+							<input id="waterNoiseThreshold" type="range" max="0.5" min="0" step="1e-3" value="0.28">
 						</div>
 						<div>
 							Resource Amount=<span id="resourceAmountLabel"></span>
@@ -59,7 +59,11 @@
 						</div>
 						<div>
 							Resource Noise threshold=<span id="noiseThresholdLabel"></span>
-							<input id="noiseThreshold" type="range" max="1" min="0" step="1e-3" value="0.45">
+							<input id="noiseThreshold" type="range" max="0.5" min="0" step="1e-3" value="0.35">
+						</div>
+						<div>
+							Noise Octaves=<span id="noiseOctavesLabel"></span>
+							<input id="noiseOctaves" type="range" max="10" min="1" step="1" value="3">
 						</div>
 						<div style="text-align: center;">
 							<button type="button" id="generateBoard">Start a new game!</button>

--- a/static/index.html
+++ b/static/index.html
@@ -59,7 +59,7 @@
 						</div>
 						<div>
 							Resource Noise threshold=<span id="noiseThresholdLabel"></span>
-							<input id="noiseThreshold" type="range" max="0.5" min="0" step="1e-3" value="0.35">
+							<input id="noiseThreshold" type="range" max="0.5" min="0" step="1e-3" value="0.30">
 						</div>
 						<div>
 							Noise Octaves=<span id="noiseOctavesLabel"></span>

--- a/static/index.html
+++ b/static/index.html
@@ -26,8 +26,9 @@
 								<option>32</option>
 								<option>48</option>
 								<option>64</option>
-								<option selected>128</option>
+								<option>128</option>
 								<option>256</option>
+								<option selected>unlimited</option>
 							</select>
 						</div>
 						<div>


### PR DESCRIPTION
Basically the same idea as Factorio.

We generate chunks as the player moves, so that the world seems to have no end.

![image](https://user-images.githubusercontent.com/2798715/126913594-6283216f-6cc1-4214-a7e2-a881d54ab80c.png)

We can specify the dynamic world by the `unlimited` option in new game settings, but we can also explicitly limit the size of the game, for the people with constrained computers.

![image](https://user-images.githubusercontent.com/2798715/126913960-823ba8ec-ffd7-4002-b1cb-1678871b569a.png)

In fact, the world is a giant HashMap of chunks, each chunk being 16 x 16 patch of tiles.

![image](https://user-images.githubusercontent.com/2798715/126913688-5f336939-bc88-4d16-81e2-4536d04ee8de.png)

Also we (re)introduce fractal noise, so that terrain features have lower frequency over wide range of area to give some incentive to explore further out.

We don't utilize the tiles to improve performance of object interactions, such as DropItems and Structures, but it will be followed by later PRs. In fact, DropItems have their own spatial index, and I'm not sure if it's a better design to enforce it in chunks structure.