### PR TITLE
Render game in 60fps

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1234,8 +1234,10 @@ let unlimited = true;
     updatePerfVisibility();
 
     function animate(){
-        if(!paused)
-            processEvents(sim.simulate(0.05));
+        if(!paused){
+            // Supposed to be 60FPS, but truth is we don't know.
+            processEvents(sim.simulate(1. / 60.));
+        }
         // let result = sim.render(ctx);
         let result = sim.render_gl(context);
 

--- a/js/main.js
+++ b/js/main.js
@@ -1233,7 +1233,7 @@ let unlimited = true;
 
     updatePerfVisibility();
 
-    window.setInterval(function(){
+    function animate(){
         if(!paused)
             processEvents(sim.simulate(0.05));
         // let result = sim.render(ctx);
@@ -1279,6 +1279,9 @@ let unlimited = true;
             });
         }
         // console.log(result);
-    }, 50);
+        requestAnimationFrame(animate);
+    }
+
+    requestAnimationFrame(animate);
     // simulate()
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -1233,10 +1233,15 @@ let unlimited = true;
 
     updatePerfVisibility();
 
+    let globalTime = performance.now();
+
     function animate(){
+        let nextTime = performance.now();
+        let deltaTime = nextTime - globalTime;
         if(!paused){
-            // Supposed to be 60FPS, but truth is we don't know.
-            processEvents(sim.simulate(1. / 60.));
+            // Supposed to be 60FPS, but truth is we don't know. requestAnimationFrame would schedule the rendering
+            // as fast as the device can.
+            processEvents(sim.simulate(deltaTime / 1000.));
         }
         // let result = sim.render(ctx);
         let result = sim.render_gl(context);
@@ -1280,6 +1285,9 @@ let unlimited = true;
                 perfLabel.appendChild(elem);
             });
         }
+
+        globalTime = nextTime;
+
         // console.log(result);
         requestAnimationFrame(animate);
     }

--- a/js/main.js
+++ b/js/main.js
@@ -1236,8 +1236,9 @@ let unlimited = true;
     let globalTime = performance.now();
 
     function animate(){
-        let nextTime = performance.now();
-        let deltaTime = nextTime - globalTime;
+        // The performance counter may not be very accurate (could have 1ms error), but it won't accumulate over time
+        const nextTime = performance.now();
+        const deltaTime = nextTime - globalTime;
         if(!paused){
             // Supposed to be 60FPS, but truth is we don't know. requestAnimationFrame would schedule the rendering
             // as fast as the device can.

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -26,7 +26,7 @@ pub(crate) struct Inserter {
     output_structure: Option<StructureId>,
 }
 
-const INSERTER_TIME: f64 = 50.;
+const INSERTER_TIME: f64 = 20.;
 
 impl Inserter {
     pub(crate) fn new(x: i32, y: i32, rotation: Rotation) -> Self {
@@ -292,9 +292,10 @@ impl Structure for Inserter {
     ) -> Result<FrameProcResult, ()> {
         let input_position = self.position.add(self.rotation.delta_inv());
         let output_position = self.position.add(self.rotation.delta());
+        let delta_time = 1. / 0.05 / 60.;
 
         if self.hold_item.is_none() {
-            if self.cooldown <= 1. {
+            if self.cooldown <= delta_time {
                 self.cooldown = 0.;
                 let ret = FrameProcResult::None;
 
@@ -391,9 +392,9 @@ impl Structure for Inserter {
                 }
                 return Ok(ret);
             } else {
-                self.cooldown -= 1.;
+                self.cooldown -= delta_time;
             }
-        } else if self.cooldown < 1. {
+        } else if self.cooldown < delta_time {
             self.cooldown = 0.;
             if let Some(item_type) = self.hold_item {
                 let Self {
@@ -429,7 +430,7 @@ impl Structure for Inserter {
                 }
             }
         } else {
-            self.cooldown -= 1.;
+            self.cooldown -= delta_time;
         }
         Ok(FrameProcResult::None)
     }

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -26,7 +26,7 @@ pub(crate) struct Inserter {
     output_structure: Option<StructureId>,
 }
 
-const INSERTER_TIME: f64 = 20.;
+const INSERTER_TIME: f64 = 50.;
 
 impl Inserter {
     pub(crate) fn new(x: i32, y: i32, rotation: Rotation) -> Self {

--- a/src/items.rs
+++ b/src/items.rs
@@ -247,8 +247,8 @@ pub(crate) fn render_drop_item_gl(
     state: &FactorishState,
     gl: &GL,
     item_type: &ItemType,
-    x: i32,
-    y: i32,
+    x: f64,
+    y: f64,
 ) -> Result<(), JsValue> {
     render_drop_item_mat_gl(
         state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,7 +1271,7 @@ impl FactorishState {
         let start_simulate = performance().now();
 
         // Prevent too slow computers from accumulating frames infinitely
-        let goal_time = self.goal_time + delta_time.min(1.);
+        let goal_time = self.goal_time + delta_time.min(0.2);
 
         const SERIALIZE_PERIOD: f64 = 100.;
         // Don't serialize more than once

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1281,12 +1281,12 @@ impl FactorishState {
         const SIM_DELTA_TIME: f64 = 1. / 60.;
 
         let mut ret = vec![];
-        let mut rendered_frames = 0;
+        // let mut rendered_frames = 0;
         while self.sim_time < goal_time {
             self.delta_time = SIM_DELTA_TIME;
             self.sim_time += SIM_DELTA_TIME;
             ret.extend(self.simulate_step(SIM_DELTA_TIME)?.into_iter());
-            rendered_frames += 1;
+            // rendered_frames += 1;
         }
 
         // In order to keep constant frame rate in simulation and rendering according to rendering capability,
@@ -1297,13 +1297,13 @@ impl FactorishState {
 
         self.perf_simulate.add(performance().now() - start_simulate);
 
-        console_log!(
-            "simulating delta_time: {:.04}, sim_time: {:.04}, goal_time: {:.04}, rendered_frames: {}",
-            delta_time,
-            self.sim_time,
-            goal_time,
-            rendered_frames
-        );
+        // console_log!(
+        //     "simulating delta_time: {:.04}, sim_time: {:.04}, goal_time: {:.04}, rendered_frames: {}",
+        //     delta_time,
+        //     self.sim_time,
+        //     goal_time,
+        //     rendered_frames
+        // );
 
         Ok(ret.iter().collect())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,7 +1271,7 @@ impl FactorishState {
         let start_simulate = performance().now();
 
         // Prevent too slow computers from accumulating frames infinitely
-        let goal_time = self.goal_time + delta_time.min(0.2);
+        let goal_time = self.goal_time + delta_time.min(0.1);
 
         const SERIALIZE_PERIOD: f64 = 100.;
         // Don't serialize more than once

--- a/src/offshore_pump.rs
+++ b/src/offshore_pump.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use web_sys::{CanvasRenderingContext2d, WebGlRenderingContext as GL};
 
+const PUMP_RATE: f64 = 1. / 3.;
+
 #[derive(Serialize, Deserialize)]
 pub(crate) struct OffshorePump {
     position: Position,
@@ -114,7 +116,7 @@ impl Structure for OffshorePump {
         structures: &mut StructureDynIter,
     ) -> Result<FrameProcResult, ()> {
         self.output_fluid_box.amount =
-            (self.output_fluid_box.amount + 1.).min(self.output_fluid_box.max_amount);
+            (self.output_fluid_box.amount + PUMP_RATE).min(self.output_fluid_box.max_amount);
         self.output_fluid_box.simulate(structures);
         Ok(FrameProcResult::None)
     }

--- a/src/ore_mine.rs
+++ b/src/ore_mine.rs
@@ -9,7 +9,7 @@ use super::{
     items::ItemType,
     structure::{RotateErr, Structure, StructureDynIter, StructureId},
     DropItem, FactorishState, FrameProcResult, Position, Recipe, Rotation, TempEnt, COAL_POWER,
-    TILE_SIZE, TILE_SIZE_I,
+    TILE_SIZE,
 };
 use cgmath::{Matrix3, Matrix4, Vector2, Vector3};
 use serde::{Deserialize, Serialize};
@@ -302,8 +302,8 @@ impl Structure for OreMine {
                                 structure
                                     .input(&DropItem {
                                         type_: *item.0,
-                                        x: output_position.x,
-                                        y: output_position.y,
+                                        x: output_position.x as f64 * TILE_SIZE,
+                                        y: output_position.y as f64 * TILE_SIZE,
                                     })
                                     .map_err(|_| ())?;
                                 if val == 0 {
@@ -322,8 +322,8 @@ impl Structure for OreMine {
                         return Ok(FrameProcResult::None);
                     }
                 }
-                let drop_x = output_position.x * TILE_SIZE_I + TILE_SIZE_I / 2;
-                let drop_y = output_position.y * TILE_SIZE_I + TILE_SIZE_I / 2;
+                let drop_x = output_position.x as f64 * TILE_SIZE + TILE_SIZE / 2.;
+                let drop_y = output_position.y as f64 * TILE_SIZE + TILE_SIZE / 2.;
                 if !hit_check(&state.drop_items, drop_x, drop_y, None)
                     && state
                         .tile_at(&output_position)

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -183,7 +183,9 @@ impl Structure for Splitter {
         match depth {
             0 => {
                 let shader = get_shader()?;
-                TransportBelt::belt_texture_gl(gl, &self.rotation, state, shader)?;
+                TransportBelt::belt_texture_gl(gl, state, shader, |scroll| {
+                    Matrix3::from_nonuniform_scale(1., 2.) * scroll
+                })?;
 
                 shape(shader)?;
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,6 +52,7 @@ impl<'a> DynIterMut for StructureEntryIterator<'a> {
 
 pub(crate) use self::iter::StructureDynIter;
 
+/// Position in tiles
 #[derive(Eq, PartialEq, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Position {
     pub x: i32,
@@ -179,7 +180,7 @@ pub(crate) enum FrameProcResult {
 }
 
 pub(crate) enum ItemResponse {
-    Move(i32, i32),
+    Move(f64, f64),
     Consume,
 }
 

--- a/src/transport_belt.rs
+++ b/src/transport_belt.rs
@@ -1,13 +1,18 @@
 use super::{
     drop_items::DropItem,
-    gl::utils::{enable_buffer, Flatten},
+    gl::{
+        utils::{enable_buffer, Flatten},
+        ShaderBundle,
+    },
     structure::{ItemResponse, ItemResponseResult, Structure, StructureDynIter},
-    FactorishState, Position, RotateErr, Rotation, TILE_SIZE,
+    FactorishState, Position, RotateErr, Rotation, SIM_DELTA_TIME, TILE_SIZE,
 };
 use cgmath::{Matrix3, Matrix4, Rad, Vector2, Vector3};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use web_sys::{CanvasRenderingContext2d, WebGlRenderingContext as GL};
+
+pub(crate) const BELT_SPEED: f64 = 0.25;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct TransportBelt {
@@ -27,8 +32,8 @@ impl TransportBelt {
         rotation: Rotation,
         item: &DropItem,
     ) -> Result<ItemResponseResult, ()> {
-        let vx = rotation.delta().0;
-        let vy = rotation.delta().1;
+        let vx = rotation.delta().0 as f64 * BELT_SPEED;
+        let vy = rotation.delta().1 as f64 * BELT_SPEED;
         let ax = if rotation.is_vertcial() {
             (item.x as f64 / TILE_SIZE).floor() * TILE_SIZE + TILE_SIZE / 2.
         } else {
@@ -39,9 +44,31 @@ impl TransportBelt {
         } else {
             item.y as f64
         };
-        let moved_x = ax as i32 + vx;
-        let moved_y = ay as i32 + vy;
+        let moved_x = ax + vx;
+        let moved_y = ay + vy;
         Ok((ItemResponse::Move(moved_x, moved_y), None))
+    }
+
+    /// Apply transformation matrix for texture with belt scrolling.
+    pub(crate) fn belt_texture_gl(
+        gl: &GL,
+        rotation: &Rotation,
+        state: &FactorishState,
+        shader: &ShaderBundle,
+    ) -> Result<(), JsValue> {
+        gl.active_texture(GL::TEXTURE0);
+        gl.bind_texture(GL::TEXTURE_2D, Some(&state.assets.tex_belt));
+        enable_buffer(&gl, &state.assets.screen_buffer, 2, shader.vertex_position);
+        let sx = -((state.sim_time / SIM_DELTA_TIME * BELT_SPEED / TILE_SIZE) % 1.) as f32;
+        gl.uniform_matrix3fv_with_f32_array(
+            shader.tex_transform_loc.as_ref(),
+            false,
+            (Matrix3::from_translation(Vector2::new(sx, 0.))
+                * Matrix3::from_angle_z(Rad(-rotation.angle_rad() as f32)))
+            .flatten(),
+        );
+
+        Ok(())
     }
 }
 
@@ -114,17 +141,7 @@ impl Structure for TransportBelt {
             .ok_or_else(|| js_str!("Shader not found"))?;
         gl.use_program(Some(&shader.program));
         gl.uniform1f(shader.alpha_loc.as_ref(), if is_ghost { 0.5 } else { 1. });
-        gl.active_texture(GL::TEXTURE0);
-        gl.bind_texture(GL::TEXTURE_2D, Some(&state.assets.tex_belt));
-        enable_buffer(&gl, &state.assets.screen_buffer, 2, shader.vertex_position);
-        let sx = -((state.sim_time * 16.) % 32. / 32.) as f32;
-        gl.uniform_matrix3fv_with_f32_array(
-            shader.tex_transform_loc.as_ref(),
-            false,
-            (Matrix3::from_translation(Vector2::new(sx, 0.))
-                * Matrix3::from_angle_z(Rad(-self.rotation.angle_rad() as f32)))
-            .flatten(),
-        );
+        TransportBelt::belt_texture_gl(gl, &self.rotation, state, shader)?;
 
         gl.uniform_matrix4fv_with_f32_array(
             shader.transform_loc.as_ref(),
@@ -135,6 +152,7 @@ impl Structure for TransportBelt {
             .flatten(),
         );
         gl.draw_arrays(GL::TRIANGLE_FAN, 0, 4);
+
         Ok(())
     }
 

--- a/src/water_well.rs
+++ b/src/water_well.rs
@@ -11,6 +11,8 @@ use web_sys::{CanvasRenderingContext2d, WebGlRenderingContext as GL};
 
 use std::cmp::Eq;
 
+const FLOW_PER_PRESSURE: f64 = 0.1 / 0.05 / 60.;
+
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub(crate) enum FluidType {
     Water,
@@ -109,7 +111,7 @@ impl FluidBox {
                     if 0. < pressure {
                         continue;
                     }
-                    let flow_amount = pressure * 0.1;
+                    let flow_amount = pressure * FLOW_PER_PRESSURE;
                     // Check input/output valve state
                     if if flow_amount < 0. {
                         !self.output_enable


### PR DESCRIPTION
We want to render the game in 60FPS if the graphics hardware is capable of. But it's not as easy as it sounds, because up until now we have assumed that graphics driver can render in less than fixed frame time (previously 50ms) at all times. If it cannot keep up with it, the whole game slows down. With higher framerate (and less frame time budget, specifically 16.6ms for 60FPS), it is much more likely that graphics driver cannot (although it took about ~6ms in my environment at maximum).

So we implement variable rendering frame rate, but at the same time we want to keep the game simulation independent of frame time as much as possible. So we fix a simulation step time (16.6ms) and run multiple steps if the rendering cannot catch up with it.

Technically, it is possible that simulation cannot catch up with 16.6ms frame time budget, but it is much less likely to happen than rendering. Because we render a lot of sprites in the screen, and WebGL API calls from Wasm have overhead, it generally takes more time in rendering. In case simulation wouldn't finish in 16ms, we have fallback mechanism to limit number of simulation steps in 60 steps maximum, but if you wouldn't make it, I guess the computer wouldn't able to play the game comfortably anyway.